### PR TITLE
Minor readability / performance / deprecation improvements

### DIFF
--- a/wordcloud/__init__.py
+++ b/wordcloud/__init__.py
@@ -181,7 +181,8 @@ def process_text(text, max_features=200, stopwords=None):
         stopwords = STOPWORDS
     
     d = {}
-    for word in re.findall(r"\w[\w']*", text, flags=re.UNICODE):
+    flags = re.UNICODE if type(text) is unicode else 0
+    for word in re.findall(r"\w[\w']*", text, flags=flags):
         if word.isdigit():
             continue
 


### PR DESCRIPTION
- replace string concat with string formatting
- replace deprecated `has_key` with `in`
- use `get` method with default instead of checking for inclusion
- replaced `lambda x: x[1]` with a single definition of `itemgetter(1)`
- use `max` with `key` instead of sort-reverse-first anti-pattern
- use unicode regex match only if the passed text is unicode
