### PR TITLE
Python3

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -7,6 +7,7 @@
 from random import Random
 import os
 import re
+import sys
 import numpy as np
 from operator import itemgetter
 
@@ -253,7 +254,8 @@ class WordCloud(object):
         """
 
         d = {}
-        flags = re.UNICODE if type(text) is str else 0
+        flags = re.UNICODE if sys.version < '3' and \
+                                type(text) is unicode else 0
         for word in re.findall(r"\w[\w']*", text, flags=flags):
             if word.isdigit():
                 continue


### PR DESCRIPTION
It maintains compatibility with Python 2 (I've run the examples and the tests with Python 2.7 and 3.4).

I've copied the test to see if we're using Python 2 on line 257 from [here](http://python3porting.com/noconv.html). In Python 3 [all strings are sequences of unicode characters](http://www.diveintopython3.net/strings.html) so there's no need to set the flags (in fact re.UNICODE is maintained by Python 3 just for retrocompatibility).

In Python 3 `zip` returns an iterator ([you can use an iterator only once](https://docs.python.org/3.1/library/stdtypes.html#iterator-types)) so on line 233 it's necessary to wrap it with `list` since we want to be able to iterate over it more than once (also that's what the script _2to3_ suggests).

In Python 3 `dict.keys` returns a [view object](https://docs.python.org/3.3/library/stdtypes.html#dict-views), so line 278 is fine because `d` is not modified (but _2to3_ to stay on the safe side actually suggests to wrap also this with `list`) but on line 284 we have to wrap it with `list` and iterate over this copy otherwise a _RuntimeError: dictionary changed size during iteration_ is raised.

In Python 2 by using `items` we are probably a little less memory efficient but the code is more clean.
