### PR TITLE
fix handling of scale parameter & python 3 compatibility for cli

### DIFF
--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -1,5 +1,4 @@
 import argparse
-import inspect
 from wordcloud import wordcloud_cli as cli
 import wordcloud as wc
 from collections import namedtuple
@@ -31,22 +30,12 @@ def all_arguments():
     return arguments
 
 
-def test_argument_spec_matches_to_constructor_args():
-    args = argparse.Namespace()
-    for option in all_arguments():
-        setattr(args, option.init_name, option.pass_value)
-
-    supported_args = inspect.getargspec(wc.WordCloud.__init__).args
-    supported_args.remove('self')
-    for arg_name in vars(args).keys():
-        assert_in(arg_name, supported_args)
-
-
 def test_main_passes_arguments_through():
     args = argparse.Namespace()
     for option in all_arguments():
         setattr(args, option.init_name, option.pass_value)
     args.imagefile = NamedTemporaryFile()
+    args.imagefile.buffer = MagicMock()
     args.text = 'some long text'
 
     with patch('wordcloud.wordcloud_cli.wc.WordCloud', autospec=True) as mock_word_cloud:

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -1,11 +1,13 @@
 import argparse
-from wordcloud import wordcloud_cli as cli
-import wordcloud as wc
+import os
 from collections import namedtuple
-from mock import patch, MagicMock
-from nose.tools import assert_equal, assert_true, assert_in
-
 from tempfile import NamedTemporaryFile
+
+import wordcloud as wc
+from wordcloud import wordcloud_cli as cli
+from mock import patch
+from nose.tools import assert_equal, assert_greater, assert_true, assert_in, assert_not_in
+
 
 temp = NamedTemporaryFile()
 ArgOption = namedtuple('ArgOption', ['cli_name', 'init_name', 'pass_value', 'fail_value'])
@@ -31,16 +33,13 @@ def all_arguments():
 
 
 def test_main_passes_arguments_through():
-    args = argparse.Namespace()
+    temp_imagefile = NamedTemporaryFile()
+
+    args = argparse.Namespace(text='some long text', imagefile=open(temp_imagefile.name, 'w'))
     for option in all_arguments():
         setattr(args, option.init_name, option.pass_value)
-    args.imagefile = NamedTemporaryFile()
-    args.imagefile.buffer = MagicMock()
-    args.text = 'some long text'
 
     with patch('wordcloud.wordcloud_cli.wc.WordCloud', autospec=True) as mock_word_cloud:
-        instance = mock_word_cloud.return_value
-        instance.to_image.return_value = MagicMock()
         cli.main(args)
 
     posargs, kwargs = mock_word_cloud.call_args
@@ -95,3 +94,16 @@ def test_parse_args_defaults_to_random_color():
 
     args = cli.parse_args(['--text', text.name])
     assert_equal(args.color_func, wc.random_color_func)
+
+
+def test_cli_writes_image():
+    # ensure writting works with all python versions
+    temp_imagefile = NamedTemporaryFile()
+    temp_textfile = NamedTemporaryFile()
+    temp_textfile.write(b'some text')
+    temp_textfile.flush()
+
+    args = cli.parse_args(['--text', temp_textfile.name, '--imagefile', temp_imagefile.name])
+    cli.main(args)
+
+    assert_greater(os.path.getsize(temp_imagefile.name), 0, msg='expecting image to be written')

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -460,14 +460,14 @@ class WordCloud(object):
         else:
             height, width = self.height, self.width
 
-        img = Image.new(self.mode, (width * self.scale, height * self.scale),
+        img = Image.new(self.mode, (int(width * self.scale), int(height * self.scale)),
                         self.background_color)
         draw = ImageDraw.Draw(img)
         for (word, count), font_size, position, orientation, color in self.layout_:
-            font = ImageFont.truetype(self.font_path, font_size * self.scale)
+            font = ImageFont.truetype(self.font_path, int(font_size * self.scale))
             transposed_font = ImageFont.TransposedFont(font,
                                                        orientation=orientation)
-            pos = (position[1] * self.scale, position[0] * self.scale)
+            pos = (int(position[1] * self.scale), int(position[0] * self.scale))
             draw.text(pos, word, fill=color, font=transposed_font)
         return img
 

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -10,7 +10,6 @@ import argparse
 import wordcloud as wc
 import numpy as np
 import sys
-import io
 from PIL import Image
 
 def main(args):
@@ -20,10 +19,9 @@ def main(args):
         color_func=args.color_func, background_color=args.background_color).generate(args.text)
     image = wordcloud.to_image()
 
-    b = io.BytesIO()
-    image.save(b, format='png')
     with args.imagefile:
-        args.imagefile.write(b.getvalue())
+        out = args.imagefile if sys.version < '3' else args.imagefile.buffer
+        image.save(out, format='png')
 
 def parse_args(arguments):
     prog = 'python wordcloud_cli.py'


### PR DESCRIPTION
- Simple solution for #116 which should work without overlap as `int` truncates.
- Adding a check for the python version when writing the output from cli.