### PR TITLE
Copy STOPWORDS and add to it, then pass it (instead of passing None).

### DIFF
--- a/examples/a_new_hope.py
+++ b/examples/a_new_hope.py
@@ -34,7 +34,7 @@ text = text.replace("HAN", "Han")
 text = text.replace("LUKE'S", "Luke")
 
 # adding movie script specific stopwords
-stopwords = STOPWORDS.copy()
+stopwords = set(STOPWORDS)
 stopwords.add("int")
 stopwords.add("ext")
 

--- a/examples/masked.py
+++ b/examples/masked.py
@@ -22,8 +22,11 @@ text = open(path.join(d, 'alice.txt')).read()
 # http://www.stencilry.org/stencils/movies/alice%20in%20wonderland/255fk.jpg
 alice_mask = np.array(Image.open(path.join(d, "alice_mask.png")))
 
+stopwords = set(STOPWORDS)
+stopwords.add("said")
+
 wc = WordCloud(background_color="white", max_words=2000, mask=alice_mask,
-               stopwords=STOPWORDS.add("said"))
+               stopwords=stopwords)
 # generate word cloud
 wc.generate(text)
 


### PR DESCRIPTION
Two of the examples accidentally pass `None` as `stopwords` (because `set.add` unfortunately doesn't return `self`). The current code works by happy coincidence because the `WordCloud` code checks to see if its `stopwords` arg is `None` (which it is) and then uses `STOPWORDS` (which has been modified by the earlier `add`) :-)
