### PR TITLE
make wc.width and wc.height into property

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -283,8 +283,8 @@ class WordCloud(object):
         self.colormap = colormap
         self.collocations = collocations
         self.font_path = font_path
-        self.width = width
-        self.height = height
+        self._width = width
+        self._height = height
         self.margin = margin
         self.prefer_horizontal = prefer_horizontal
         self.mask = mask
@@ -310,6 +310,20 @@ class WordCloud(object):
                           " it had no effect. Look into relative_scaling.",
                           DeprecationWarning)
         self.normalize_plurals = normalize_plurals
+        
+    @property
+    def height(self):
+        if self.mask is not None:
+            return self.mask.shape[0]
+        else:
+            return self._height
+      
+    @property
+    def width(self):
+        if self.mask is not None:
+            return self.mask.shape[1]
+        else:
+            return self._width
 
     def fit_words(self, frequencies):
         """Create a word_cloud from words and frequencies.


### PR DESCRIPTION
fetch wc.mask for width and height queries if mask exists, otherwise use user specified shapes. This is mainly for better consistency, ease of use and to help clarify ambiguities:

e.g. `wc.width` now gives same result as `wc.mask.shape[1]`, so the user can use the former. The latter form is less intuitive and not obvious unless one reads into the code.
e.g. if a `wc` obj was created using default shape, and a mask was assigned later that has a different shape, now the shape of `wc` gets updated by new shape of the mask.