### PR TITLE
Adding support to render numbers

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -61,6 +61,24 @@ def test_plurals_numbers():
     assert_in("better than", wc.words_)
 
 
+def test_render_numbers():
+    text = THIS + "\n" + "1, 2, 3, 1 number 2 numbers 3 numbers although many Numbers"
+    wc = WordCloud(stopwords=[], render_numbers=True).generate(text)
+    # not capitalized usually
+    assert_not_in("Numbers", wc.words_)
+    # plural removed
+    assert_not_in("numbers", wc.words_)
+    # numbers not removed
+    assert_in("1", wc.words_)
+    assert_in("2", wc.words_)
+    assert_in("3", wc.words_)
+    # usually capitalized
+    assert_not_in("although", wc.words_)
+    assert_in("number", wc.words_)
+    assert_in("Although", wc.words_)
+    assert_in("better than", wc.words_)
+
+
 def test_multiple_s():
     text = 'flo flos floss flosss'
     wc = WordCloud(stopwords=[]).generate(text)
@@ -230,3 +248,6 @@ def test_generate_from_frequencies():
     result = wc.generate_from_frequencies(words)
 
     assert_true(isinstance(result, WordCloud))
+
+
+test_render_numbers()

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -241,6 +241,10 @@ class WordCloud(object):
         is removed and its counts are added to the version without
         trailing 's' -- unless the word ends with 'ss'.
 
+    render_numbers : bool, default=False
+        Whether to include numbers as words for the WordCloud. This could
+        be useful in case of handle categorical data or dates.
+
     Attributes
     ----------
     ``words_`` : dict of string to float
@@ -269,7 +273,7 @@ class WordCloud(object):
                  stopwords=None, random_state=None, background_color='black',
                  max_font_size=None, font_step=1, mode="RGB",
                  relative_scaling=.5, regexp=None, collocations=True,
-                 colormap=None, normalize_plurals=True):
+                 colormap=None, normalize_plurals=True, render_numbers=False):
         if font_path is None:
             font_path = FONT_PATH
         if color_func is None and colormap is None:
@@ -310,6 +314,7 @@ class WordCloud(object):
                           " it had no effect. Look into relative_scaling.",
                           DeprecationWarning)
         self.normalize_plurals = normalize_plurals
+        self.render_numbers = render_numbers
 
     def fit_words(self, frequencies):
         """Create a word_cloud from words and frequencies.
@@ -511,8 +516,9 @@ class WordCloud(object):
         # remove 's
         words = [word[:-2] if word.lower().endswith("'s") else word
                  for word in words]
-        # remove numbers
-        words = [word for word in words if not word.isdigit()]
+        if self.render_numbers is False:
+            # remove numbers
+            words = [word for word in words if not word.isdigit()]
 
         if self.collocations:
             word_counts = unigrams_and_bigrams(words, self.normalize_plurals)

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -508,7 +508,7 @@ class WordCloud(object):
 
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode
                  else 0)
-        regexp = self.regexp if self.regexp is not None else r"\w[\w']+"
+        regexp = self.regexp if self.regexp is not None else r"(\w[\w']+|\w+)"
 
         words = re.findall(regexp, text, flags)
         # remove stopwords


### PR DESCRIPTION
According to the issue #202, this refactor only adds a boolean argument 'render_numbers' in WordCloud class for indicating if the words which are numbers should be deleted or not.

2 core affected lines:
https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L272 (WordCloud.__init__)
https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L514-L515 (WordCloud.process_text)

Regards