### PR TITLE
Use native Unicode font on Window & macOS, ignore missing stopword file

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -26,10 +26,33 @@ from .tokenization import unigrams_and_bigrams, process_tokens
 
 item1 = itemgetter(1)
 
-FONT_PATH = os.environ.get("FONT_PATH", os.path.join(os.path.dirname(__file__),
-                                                     "DroidSansMono.ttf"))
-STOPWORDS = set([x.strip() for x in open(
-    os.path.join(os.path.dirname(__file__), 'stopwords')).read().split('\n')])
+def selectFont(path):
+    result = ''
+    fontsToTry = ['ARIALUNI.ttf', 'Arial Unicode.ttf', 'arial.ttf']
+    for font in fontsToTry:
+        testFont = os.path.join(path, font)
+        if os.path.exists(testFont):
+            result = testFont
+            break
+    return result
+    
+if sys.platform.startswith('win'):
+    FONT_PATH = selectFont(os.path.join(os.environ['WINDIR'], 'Fonts'))
+elif sys.platform.startswith('darwin'):
+    FONT_PATH = selectFont('/Library/Fonts')
+else:
+    FONT_PATH = ''
+
+if FONT_PATH == '':
+    FONT_PATH = os.environ.get("FONT_PATH", os.path.join(os.path.dirname(__file__),
+                                                         "DroidSansMono.ttf"))
+
+# Trap if "stopwords" file does not exist
+try:
+    STOPWORDS = set([x.strip() for x in open(os.path.join(os.path.dirname(__file__),
+                                                          'stopwords')).read().split('\n')])
+except:
+    STOPWORDS = set()
 
 
 class IntegralOccupancyMap(object):


### PR DESCRIPTION
I've modified FONT_PATH so it seeks a font on Windows and macOS that supports Unicode characters, such as Chinese and Arabic.  If this fails, or if you are on Linux, it falls back to the DroidSansMono font.

Also, if the default stopwords file is missing, the program creates an empty set.  (I didn't want default stopwords, and py2exe on Windows didn't copy the stopwords file.)