### PR TITLE
Always pass integral font_size

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -429,7 +429,7 @@ class WordCloud(object):
             tried_other_orientation = False
             while True:
                 # try to find a position
-                font = ImageFont.truetype(self.font_path, font_size)
+                font = ImageFont.truetype(self.font_path, int(font_size))
                 # transpose font optionally
                 transposed_font = ImageFont.TransposedFont(
                     font, orientation=orientation)


### PR DESCRIPTION
In some cases the value of font_size would be a float, causing runtime errors.

I added a `print` statement:

```python
print("font %s size %s index %s encoding %s" % (font, size, index, encoding))
```

to `ImageFont.py:127` after observing errors and saw this output:

```
$ cat _posts/*.md | wordcloud_cli.py --stopwords stopwords.txt --imagefile wordcloud.png
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 200 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 200 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 200 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 199 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 198 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 197 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 196 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 195 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 194 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 193 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 192 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 191 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 190 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 189 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 188 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 187 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 186 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 185 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 184 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 183 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 182 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 181 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 180 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 179 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 178 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 177 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 176 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 175 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 174 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 173 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 172 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 171 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 170 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 169 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 168 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 167 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 166 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 165 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 164 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 163 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 162 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 161 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 160 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 159 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 158 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 157 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 156 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 155 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 154 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 153 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 152 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 151 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 150 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 149 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 148 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 147 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 146 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 145 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 144 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 143 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 142 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 141 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 140 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 139 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 138 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 137 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 136 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 135 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 134 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 133 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 132 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 131 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 130 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 129 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 128 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 127 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 126 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 125 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 124 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 123 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 122 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 121 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 120 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 119 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 118 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 117 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 116 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 115 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 114 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 113 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 112 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 111 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 110 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 109 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 108 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 107 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 106 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 105 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 104 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 103 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 102 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 101 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 100 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 99 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 98 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 97 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 96 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 95 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 94 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 93 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 92 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 91 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 90 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 89 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 88 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 87 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 86 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 85 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 84 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 83 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 82 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 81 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 80 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 79 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 78 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 77 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 76 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 75 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 74 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 73 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 72 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 71 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 70 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 69 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 68 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 67 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 66 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 65 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 64 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 63 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 62 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 61 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 60 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 59 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 58 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 57 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 56 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 55 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 54 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 53 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 52 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 51 index 0 encoding
font /Library/Python/2.7/site-packages/wordcloud/DroidSansMono.ttf size 81.2749003984 index 0 encoding
Traceback (most recent call last):
  File "/usr/local/bin/wordcloud_cli.py", line 81, in <module>
    main(parse_args(sys.argv[1:]))
  File "/usr/local/bin/wordcloud_cli.py", line 19, in main
    color_func=args.color_func, background_color=args.background_color).generate(args.text)
  File "/Library/Python/2.7/site-packages/wordcloud/wordcloud.py", line 556, in generate
    return self.generate_from_text(text)
  File "/Library/Python/2.7/site-packages/wordcloud/wordcloud.py", line 542, in generate_from_text
    self.generate_from_frequencies(words)
  File "/Library/Python/2.7/site-packages/wordcloud/wordcloud.py", line 432, in generate_from_frequencies
    font = ImageFont.truetype(self.font_path, font_size)
  File "/Library/Python/2.7/site-packages/PIL/ImageFont.py", line 239, in truetype
    return FreeTypeFont(font, size, index, encoding)
  File "/Library/Python/2.7/site-packages/PIL/ImageFont.py", line 128, in __init__
    self.font = core.getfont(font, size, index, encoding)
TypeError: integer argument expected, got float
```

Somehow, in certain edge cases, the value of `font_size` was a float. By converting it to `int` we ensure that the passed value never breaks.

This is the same error as in #191.