### PR TITLE
Move check for empty frequencies before first access, and raise ValueError if check fails.

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -76,6 +76,16 @@ def test_multiple_s():
     assert_in("flosss", wc.words_)
 
 
+def test_empty_text():
+    # test originally empty text raises an exception
+    wc = WordCloud(stopwords=[])
+    assert_raises(ValueError, wc.generate, '')
+
+    # test empty-after-filtering text raises an exception
+    wc = WordCloud(stopwords=['a', 'b'])
+    assert_raises(ValueError, wc.generate, 'a b a')
+
+
 def test_default():
     # test that default word cloud creation and conversions work
     wc = WordCloud(max_words=50)

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -348,7 +348,11 @@ class WordCloud(object):
         """
         # make sure frequencies are sorted and normalized
         frequencies = sorted(frequencies.items(), key=item1, reverse=True)
+        if len(frequencies) <= 0:
+            raise ValueError("We need at least 1 word to plot a word cloud, "
+                             "got %d." % len(frequencies))
         frequencies = frequencies[:self.max_words]
+
         # largest entry will be 1
         max_frequency = float(frequencies[0][1])
 
@@ -359,10 +363,6 @@ class WordCloud(object):
             random_state = self.random_state
         else:
             random_state = Random()
-
-        if len(frequencies) <= 0:
-            print("We need at least 1 word to plot a word cloud, got %d."
-                  % len(frequencies))
 
         if self.mask is not None:
             mask = self.mask


### PR DESCRIPTION
Fixes #201 by moving check just after `frequencies` definition and raising a `ValueError` if the check fails (rather than just printing).  I've always felt a little unsure about which exception to raise, but raising an exception seems like the desired behavior here (rather than just printing an error to stdout)?  The added tests fail before the patch is applied.