### PR TITLE
Parametrize minimum word length.

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -47,6 +47,26 @@ def test_collocations():
     assert_not_in("way may", wc2.words_)
 
 
+def test_min_word_length():
+    text = 'take a walky walk walk'
+
+    wc1 = WordCloud(stopwords=[], min_word_length=1)
+    wc1.generate(text)
+
+    wc2 = WordCloud(stopwords=[], min_word_length=2)
+    wc2.generate(text)
+
+    wc5 = WordCloud(stopwords=[], min_word_length=5)
+    wc5.generate(text)
+
+    assert_in('a', wc1.words_)
+    assert_in('walk', wc1.words_)
+    assert_not_in('a', wc2.words_)
+    assert_in('walk', wc2.words_)
+    assert_not_in('a', wc5.words_)
+    assert_not_in('walk', wc5.words_)
+
+
 def test_plurals_numbers():
     text = THIS + "\n" + "1 idea 2 ideas three ideas although many Ideas"
     wc = WordCloud(stopwords=[]).generate(text)

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -17,7 +17,8 @@ ARGUMENT_SPEC_TYPED = [
     ArgOption(cli_name='width', init_name='width', pass_value=13, fail_value=1.),
     ArgOption(cli_name='height', init_name='height', pass_value=15, fail_value=1.),
     ArgOption(cli_name='margin', init_name='margin', pass_value=17, fail_value=1.),
-    ArgOption(cli_name='relative_scaling', init_name='relative_scaling', pass_value=1, fail_value='c')
+    ArgOption(cli_name='relative_scaling', init_name='relative_scaling', pass_value=1, fail_value='c'),
+    ArgOption(cli_name='min_word_length', init_name='min_word_length', pass_value=1, fail_value=1.)
 ]
 ARGUMENT_SPEC_REMAINING = [
     ArgOption(cli_name='stopwords', init_name='stopwords', pass_value=temp.name, fail_value=None),

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -244,6 +244,10 @@ class WordCloud(object):
         is removed and its counts are added to the version without
         trailing 's' -- unless the word ends with 'ss'.
 
+    min_word_length : int, default=2
+        Minimum length of words to consider (words shorter than this
+        length will be discarded).
+
     Attributes
     ----------
     ``words_`` : dict of string to float
@@ -272,7 +276,7 @@ class WordCloud(object):
                  stopwords=None, random_state=None, background_color='black',
                  max_font_size=None, font_step=1, mode="RGB",
                  relative_scaling=.5, regexp=None, collocations=True,
-                 colormap=None, normalize_plurals=True):
+                 colormap=None, normalize_plurals=True, min_word_length=2):
         if font_path is None:
             font_path = FONT_PATH
         if color_func is None and colormap is None:
@@ -313,6 +317,7 @@ class WordCloud(object):
                           " it had no effect. Look into relative_scaling.",
                           DeprecationWarning)
         self.normalize_plurals = normalize_plurals
+        self.min_word_length = min_word_length
 
     def fit_words(self, frequencies):
         """Create a word_cloud from words and frequencies.
@@ -507,9 +512,11 @@ class WordCloud(object):
 
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode
                  else 0)
-        regexp = self.regexp if self.regexp is not None else r"\w[\w']+"
+        regexp = self.regexp if self.regexp is not None else r"\w[\w']*"
 
         words = re.findall(regexp, text, flags)
+        # remove short words
+        words = [word for word in words if len(word) >= self.min_word_length]
         # remove stopwords
         words = [word for word in words if word.lower() not in stopwords]
         # remove 's

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -16,7 +16,8 @@ def main(args):
     wordcloud = wc.WordCloud(stopwords=args.stopwords, mask=args.mask,
         width=args.width, height=args.height, font_path=args.font_path,
         margin=args.margin, relative_scaling=args.relative_scaling,
-        color_func=args.color_func, background_color=args.background_color).generate(args.text)
+        color_func=args.color_func, background_color=args.background_color,
+        min_word_length=args.min_word_length).generate(args.text)
     image = wordcloud.to_image()
 
     with args.imagefile:
@@ -51,6 +52,8 @@ def parse_args(arguments):
         help='use given color as coloring for the image - accepts any value from PIL.ImageColor.getcolor')
     parser.add_argument('--background', metavar='color', default='black', type=str, dest='background_color',
         help='use given color as background color for the image - accepts any value from PIL.ImageColor.getcolor')
+    parser.add_argument('--min_word_length',default=2, type=int,
+        help='minimum length of words to consider (discard words shorter than this length)')
     args = parser.parse_args(arguments)
 
     if args.colormask and args.color:


### PR DESCRIPTION
This PR adds a `min_word_length` option to `WordCloud` and a `--min_word_length` flag to the CLI that control the threshold at which short words are removed from the data during processing.  The default is 2, preserving the existing behavior.

Justification: for science applications it may be preferable to see all words input to the word cloud, with the understanding that the user has pre-processed the text according to a specific procedure before using wordcloud.

Closes #240.