### PR TITLE
Update conda link to avoid redirects

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -20,7 +20,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # Use the miniconda installer for faster download / install of conda
     # itself
-    wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
+    wget https://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
         -O miniconda.sh
     chmod +x miniconda.sh && ./miniconda.sh -b
     export PATH=/home/travis/miniconda/bin:$PATH


### PR DESCRIPTION
Fixes these in travis jobs:

> $ source continuous_integration/install.sh
--...--  http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh
Resolving repo.continuum.io (repo.continuum.io)... 104.16.19.10, 104.16.18.10, 2400:cb00:2048:1::6810:120a, ...
Connecting to repo.continuum.io (repo.continuum.io)|104.16.19.10|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh [following]
--...--  https://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh