### PR TITLE
Added SO tag cloud info

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ word clouds for twitter users when it is mentioned with a particular hashtag.
 [Here][twitter-wordnuvola] you can see it in action, while [here][imgur-wordnuvola]
 you can see all the word clouds generated so far.
 
+### Stack Overflow Users Tag Cloud
+
+Generate tag clouds of users on [Stack Overflow](http://stackoverflow.com/) or any [Stack Exchange site](https://stackexchange.com/sites). If you are contributing to Stack Overflow community, it's an easy way to share your expertise with someone through an image. Here's Stack Overflow's highest reputation user [Jon Skeet's](http://stackoverflow.com/users/22656/jon-skeet) tag cloud -
+
+![Screenshot](https://raw.githubusercontent.com/droyed/stackoverflow_tag_cloud/master/example_output/example_extensive_output.png)
+
 ### [other]
 
 *Send a pull request to add yours here.*

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ you can see all the word clouds generated so far.
 
 ### Stack Overflow Users Tag Cloud
 
-Generate tag clouds of users on [Stack Overflow](http://stackoverflow.com/) or any [Stack Exchange site](https://stackexchange.com/sites). If you are contributing to Stack Overflow community, it's an easy way to share your expertise with someone through an image. Here's Stack Overflow's highest reputation user [Jon Skeet's](http://stackoverflow.com/users/22656/jon-skeet) tag cloud -
+[Stackoverflow Tag Cloud](https://github.com/droyed/stackoverflow_tag_cloud) generates tag clouds of users on [Stack Overflow](http://stackoverflow.com/) or any [Stack Exchange site](https://stackexchange.com/sites). If you are contributing to Stack Overflow community, it's an easy way to share your expertise with others through an image. Here's Stack Overflow's highest reputation user [Jon Skeet's](http://stackoverflow.com/users/22656/jon-skeet) tag cloud -
 
 ![Screenshot](https://raw.githubusercontent.com/droyed/stackoverflow_tag_cloud/master/example_output/example_extensive_output.png)
 


### PR DESCRIPTION
As an usage, added repository information on [Stack Overflow Users Tag Cloud](https://github.com/droyed/stackoverflow_tag_cloud) into README.