### PR TITLE
Fix for unicode stopwords files

### DIFF
--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -150,7 +150,7 @@ def parse_args(arguments):
 
     if args['stopwords']:
         with args.pop('stopwords') as f:
-            args['stopwords'] = set(map(str.strip, f.readlines()))
+            args['stopwords'] = set(map(lambda l: l.strip(), f.readlines()))
 
     if args['mask']:
         mask = args.pop('mask')


### PR DESCRIPTION
Passing stopwords file with unicode characters caused

```python
TypeError: descriptor 'strip' requires a 'str' object but received a 'unicode'
```