### PR TITLE
Add option to reduce generated image size

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -654,7 +654,7 @@ class WordCloud(object):
         """
 
         img = self.to_image()
-        img.save(filename)
+        img.save(filename, optimize=True)
         return self
 
     def to_array(self):

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -80,7 +80,7 @@ def main(args, text, imagefile):
     image = wordcloud.to_image()
 
     with imagefile:
-        image.save(imagefile, format='png')
+        image.save(imagefile, format='png', optimize=True)
 
 
 def parse_args(arguments):


### PR DESCRIPTION
See documentation here: http://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
Basically for file types where the option is supported smaller images should be generated if that is possible. For the one's not supporting that flag it is ignored (http://pillow.readthedocs.io/en/stable/reference/Image.html?#PIL.Image.Image.save).