### PR TITLE
Avoid relative import in wordcloud_cli.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY_VERSION="1.13.1"
 install: source continuous_integration/install.sh
 cache: apt
-script: nosetests
+script: nosetests && test/test_script.sh

--- a/test/test_script.sh
+++ b/test/test_script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Test whether the installed script (executable) works.
+
+echo "Test the command line utility..."
+wordcloud_cli.py --help

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -6,6 +6,8 @@ Usage::
 
     $ wordcloud_cli.py --text=words.txt --stopwords=stopwords.txt
 """
+from __future__ import absolute_import
+
 import sys
 import io
 import re
@@ -14,7 +16,7 @@ import wordcloud as wc
 import numpy as np
 from PIL import Image
 
-from . import __version__
+from wordcloud import __version__
 
 
 class FileType(object):


### PR DESCRIPTION
The relative import in wordcloud_cli.py makes it unusable. The following error always occurs on
Python 3.x:

Parent module '' not loaded, cannot perform relative import