### PR TITLE
circleci: Fix workspace issue avoiding to generate deprecated egg

### DIFF
--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -47,8 +47,7 @@ build:
     # Built distribution (wheel)
     - $<RUN_ENV> python setup.py bdist_wheel $<SETUP_BDIST_WHEEL_ARGS>
     # Install locally to support tests
-    - $<RUN_ENV> python setup.py build_ext --inplace
-    - $<RUN_ENV> python setup.py install
+    - $<RUN_ENV> pip install -e .
     # Cleanup
     - python: |
               import glob, os


### PR DESCRIPTION
Using "pip install -e" is sufficient to build in place and allow the
test to work as expected.

This commit fixes the following error:

Concurrent upstream jobs persisted the same file(s) into the workspace:
  - dist/wordcloud-1.4.1-py2.7-linux-x86_64.egg