### PR TITLE
Use raw string where appropriate.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,7 +68,7 @@ sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     # path where to save gallery generated examples
     'gallery_dirs': 'auto_examples',
-    'filename_pattern': '/\w+',
+    'filename_pattern': r'/\w+',
     'doc_module': ('wordcloud',),
     'reference_url': {
         # The module you locally document uses None

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -147,7 +147,7 @@ def get_single_color_func(color):
 
 
 class WordCloud(object):
-    """Word cloud object for generating and drawing.
+    r"""Word cloud object for generating and drawing.
 
     Parameters
     ----------


### PR DESCRIPTION
Since the Wordcloud docstring includes a backslash, it should be a raw string
See https://www.python.org/dev/peps/pep-0257/#id15

Similarly, regular expression must also be raw string.
See https://docs.python.org/3/library/re.html

See #375

Co-authored-by: Hossein Pourbozorg <hussein.pourbozorg@gmail.com>