### PR TITLE
cli: Install executable using entry_points

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ Getting fancy with some colors:
 
 ## Command-line usage
 
-The `wordcloud_cli.py` tool can be used to generate word clouds directly from the command-line:
+The `wordcloud_cli` tool can be used to generate word clouds directly from the command-line:
 
-	$ wordcloud_cli.py --text mytext.txt --imagefile wordcloud.png
+	$ wordcloud_cli --text mytext.txt --imagefile wordcloud.png
 
 If you're dealing with PDF files, then `pdftotext`, included by default with many Linux distribution, comes in handy:
 
-	$ pdftotext mydocument.pdf - | wordcloud_cli.py --imagefile wordcloud.png
+	$ pdftotext mydocument.pdf - | wordcloud_cli --imagefile wordcloud.png
 
 In the previous example, the `-` argument orders `pdftotext` to write the resulting text to stdout, which is then piped to the stdin of `wordcloud_cli.py`.
 
-Use `wordcloud_cli.py --help` so see all available options.
+Use `wordcloud_cli --help` so see all available options.
 
 [blog-post]: http://peekaboo-vision.blogspot.de/2012/11/a-wordcloud-in-python.html
 [website]: http://amueller.github.io/word_cloud/

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -55,12 +55,16 @@ Wheels
 
   * Remove use of miniconda and instead use `manylinux`_ docker images.
 
+* Fix installation of the cli on all platforms leveraging `entry_points`_.
+  See :issue:`420`. Contributed by :user:`jcfr`.
+
 .. _manylinux: https://www.python.org/dev/peps/pep-0571/
 .. _PyPI: https://pypi.org/project/wordcloud
 .. _scikit-ci: http://scikit-ci.readthedocs.io
 .. _scikit-ci-addons: http://scikit-ci-addons.readthedocs.io
 .. _scikit-ci.yml: https://github.com/amueller/word_cloud/blob/master/scikit-ci.yml
 .. _versioneer: https://github.com/warner/python-versioneer/
+.. _entry_points: https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
 
 Bug fixes
 ---------

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -6,4 +6,4 @@ Command Line Interface
 .. argparse::
    :module: wordcloud.wordcloud_cli
    :func: make_parser
-   :prog: wordcloud_cli.py
+   :prog: wordcloud_cli

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     test_requires=['matplotlib'],
     ext_modules=[Extension("wordcloud.query_integral_image",
                            ["wordcloud/query_integral_image.c"])],
-    scripts=['wordcloud/wordcloud_cli.py'],
+    entry_points={'console_scripts': ['wordcloud_cli=wordcloud.__main__:main']},
     packages=['wordcloud'],
     package_data={'wordcloud': ['stopwords', 'DroidSansMono.ttf']}
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,3 +6,24 @@ def tmp_text_file(tmpdir_factory):
     fn = tmpdir_factory.mktemp("data").join("empty.txt")
     fn.write(b'')
     return fn
+
+
+@pytest.fixture
+def no_cover_compat(request):
+    """A pytest fixture to disable coverage.
+
+    .. note::
+
+         After the next version of ``pytest-cov`` is released, it will be possible to directly
+         use the ``no_cover`` fixture or marker.
+    """
+
+    # Check with hasplugin to avoid getplugin exception in older pytest.
+    if request.config.pluginmanager.hasplugin('_cov'):
+        plugin = request.config.pluginmanager.getplugin('_cov')
+        if plugin.cov_controller:
+            plugin.cov_controller.cov.stop()
+            plugin.cov_controller.unset_env()
+            yield plugin.cov_controller
+            plugin.cov_controller.set_env()
+            plugin.cov_controller.cov.start()

--- a/test/test_script.sh
+++ b/test/test_script.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Test whether the installed script (executable) works.
-
-echo "Test the command line utility..."
-wordcloud_cli.py --help

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 from collections import namedtuple
 
 import wordcloud as wc
@@ -143,3 +144,26 @@ def test_cli_regexp_invalid(tmp_text_file, capsys):
 
     _, err = capsys.readouterr()
     assert "Invalid regular expression" in err
+
+
+@pytest.mark.parametrize("command,expected_output, expected_exit_code", [
+    ("wordcloud_cli --help", "usage: wordcloud_cli", 0),
+    ("python -m wordcloud --help", "usage: __main__", 0),
+    ("python %s/../wordcloud/wordcloud_cli.py --help" % os.path.dirname(__file__), "To execute the CLI", 1),
+])
+def test_cli_as_executable(command, expected_output, expected_exit_code, tmpdir, capfd, no_cover_compat):
+
+    ret_code = 0
+    try:
+        subprocess.check_call(
+            command,
+            shell=True,
+            cwd=str(tmpdir)
+        )
+    except subprocess.CalledProcessError as excinfo:
+        ret_code = excinfo.returncode
+
+    out, err = capfd.readouterr()
+    assert expected_output in out if ret_code == 0 else err
+
+    assert ret_code == expected_exit_code

--- a/wordcloud/__main__.py
+++ b/wordcloud/__main__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Command line tool to generate word clouds
+
+The name ``__main__.py`` is important as it enables execution
+of the module using ``python -m wordcloud`` syntax.
+
+Usage:
+
+* using ``wordcloud_cli`` executable::
+
+    $ cat word.txt | wordcloud_cli
+
+    $ wordcloud_cli --text=words.txt --stopwords=stopwords.txt
+
+* using ``wordcloud`` module::
+
+    $ cat word.txt | python -m wordcloud
+
+    $ python -m wordcloud --text=words.txt --stopwords=stopwords.txt
+"""
+
+import sys
+
+from .wordcloud_cli import main as wordcloud_cli_main
+from .wordcloud_cli import parse_args as wordcloud_cli_parse_args
+
+
+def main():
+    """The main entry point to wordcloud_cli``.
+
+    This is installed as the script entry point.
+    """
+    wordcloud_cli_main(*wordcloud_cli_parse_args(sys.argv[1:]))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -1,14 +1,23 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-r"""Command-line tool to generate word clouds
-Usage::
-    $ cat word.txt | wordcloud_cli.py
-
-    $ wordcloud_cli.py --text=words.txt --stopwords=stopwords.txt
+"""Command-line tool interface to generate word clouds.
 """
 from __future__ import absolute_import
 
 import sys
+import textwrap
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(textwrap.dedent(
+        """
+        To execute the CLI, instead consider running:
+
+          wordcloud_cli --help
+
+        or
+
+          python -m wordcloud --help
+        """))
+
 import io
 import re
 import argparse
@@ -16,7 +25,7 @@ import wordcloud as wc
 import numpy as np
 from PIL import Image
 
-from wordcloud import __version__
+from . import __version__
 
 
 class FileType(object):
@@ -185,7 +194,3 @@ def parse_args(arguments):
     imagefile = args.pop('imagefile')
 
     return args, text, imagefile
-
-
-if __name__ == '__main__':  # pragma: no cover
-    main(*parse_args(sys.argv[1:]))


### PR DESCRIPTION
This allows to have a consistent way of execution the CLI on all
platforms. On windows, an executable launcher is automatically created
after installing the package:

* https://packaging.python.org/guides/distributing-packages-using-setuptools/#console-scripts
* https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation


This commit also makes it possible for developer to modify the `wordcloud/wordcloud_cli.py`
script after doing an editable install and ensure the updates are considered
without having to re-install.

After downloading the source, if a user tries to directly execute `wordcloud/worcloud_cli.py`,
instead of getting the error message:

```
  SystemError: Parent module '' not loaded, cannot perform relative import
```

it now shows an informative message suggesting how to run the CLI:

```
  To execute the CLI, instead consider running:

    wordcloud_cli --help

  or

    python -m wordcloud --help
```

Fixes #420