### PR TITLE
stopwords now compatible with unicode and str types for python 2.7

### DIFF
--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -175,7 +175,7 @@ def parse_args(arguments):
 
     if args['stopwords']:
         with args.pop('stopwords') as f:
-            args['stopwords'] = set(map(str.strip, f.readlines()))
+            args['stopwords'] = set(map(lambda it: it.strip(), f.readlines()))
 
     if args['mask']:
         mask = args.pop('mask')


### PR DESCRIPTION
fixes #436 

Thought this fix would be helpful since [README](https://github.com/amueller/word_cloud/blob/master/README.md) says the framework supports `Python 2.7, 3.4, 3.5, 3.6 and 3.7.`