### PR TITLE
Add to_svg

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -6,6 +6,7 @@ import pytest
 from random import Random
 from numpy.testing import assert_array_equal
 from PIL import Image
+import xml.etree.ElementTree as ET
 
 import matplotlib
 matplotlib.use('Agg')
@@ -152,6 +153,13 @@ def test_check_errors():
         raise AssertionError("wc.recolor didn't raise")
     except ValueError as e:
         assert "call generate" in str(e)
+
+
+def test_svg_syntax():
+    wc = WordCloud()
+    wc.generate(THIS)
+    svg = wc.to_svg()
+    ET.fromstring(svg)
 
 
 def test_recolor():

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -732,7 +732,7 @@ class WordCloud(object):
     def to_html(self):
         raise NotImplementedError("FIXME!!!")
 
-    def to_svg(self, embed_image=False, embed_font=False):
+    def to_svg(self, embed_font=False, optimize_embedded_font=True, embed_image=False):
         """Export to SVG.
 
         Font is assumed to be available to the SVG reader. Otherwise, text
@@ -749,12 +749,17 @@ class WordCloud(object):
 
         Parameters
         ----------
+        embed_font : bool, default=False
+            Whether to include font inside resulting SVG file.
+
+        optimize_embedded_font : bool, default=True
+            Whether to be aggressive when embedding a font, to reduce size. In
+            particular, hinting tables are dropped, which may introduces slight
+            changes to character shapes (w.r.t. `to_image` baseline).
+
         embed_image : bool, default=False
             Whether to include rasterized image inside resulting SVG file.
             Useful for debugging.
-
-        embed_font : bool, default=False
-            Whether to include font inside resulting SVG file.
 
         Returns
         -------
@@ -825,10 +830,10 @@ class WordCloud(object):
             options = fontTools.subset.Options(
 
                 # Small impact on character shapes, but reduce size a lot
-                hinting=False,
+                hinting=not optimize_embedded_font,
 
                 # On small subsets, can improve size
-                desubroutinize=True,
+                desubroutinize=optimize_embedded_font,
 
                 # Try to be lenient
                 ignore_missing_glyphs=True,

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -9,8 +9,10 @@ from __future__ import division
 
 import warnings
 from random import Random
+import io
 import os
 import re
+import base64
 import sys
 import colorsys
 import matplotlib
@@ -729,7 +731,7 @@ class WordCloud(object):
     def to_html(self):
         raise NotImplementedError("FIXME!!!")
     
-    def to_svg(self):
+    def to_svg(self, embed_image=False):
         """Export to SVG.
 
         Returns
@@ -796,6 +798,21 @@ class WordCloud(object):
                 '>'
                 '</rect>'
                 .format(self.background_color)
+            )
+        
+        # Embed image, useful for debug purpose
+        if embed_image:
+            image = self.to_image()
+            data = io.BytesIO()
+            image.save(data, format='JPEG')
+            data = base64.b64encode(data.getbuffer()).decode('ascii')
+            result.append(
+                '<image'
+                ' width="100%"'
+                ' height="100%"'
+                ' href="data:image/jpg;base64,{}"'
+                '/>'
+                .format(data)
             )
 
         # For each word in layout

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -742,13 +742,12 @@ class WordCloud(object):
         self._check_generated()
 
         # Get output size, in pixels
-        # TODO check self.scale
         if self.mask is not None:
             width = self.mask.shape[1]
             height = self.mask.shape[0]
         else:
             height, width = self.height, self.width
-        
+
         # Get max font size
         if self.max_font_size is None:
             max_font_size = max(w[1] for w in self.layout_)
@@ -760,7 +759,7 @@ class WordCloud(object):
 
         # Prepare global style
         style = {}
-        font = ImageFont.truetype(self.font_path, int(max_font_size))
+        font = ImageFont.truetype(self.font_path, int(max_font_size * self.scale))
         font_family, font_style = font.getname()
         # TODO properly escape/quote this
         # TODO should add option to specify URL for font (i.e. WOFF file)
@@ -783,7 +782,7 @@ class WordCloud(object):
             ' height="{}"'
             ' style="{}"'
             '>'
-            .format(width, height, style)
+            .format(width * self.scale, height * self.scale, style)
         )
 
         # Add background
@@ -800,12 +799,14 @@ class WordCloud(object):
 
         # For each word in layout
         for (word, count), font_size, (y, x), orientation, color in self.layout_:
+            x *= self.scale
+            y *= self.scale
 
             # Get text metrics
-            font = ImageFont.truetype(self.font_path, int(font_size))
+            font = ImageFont.truetype(self.font_path, int(font_size * self.scale))
             (size_x, size_y), (offset_x, offset_y) = font.font.getsize(word)
             ascent, descent = font.getmetrics()
-            
+
             # Compute text bounding box
             min_x = offset_x
             max_x = size_x - offset_x
@@ -822,7 +823,7 @@ class WordCloud(object):
                 x += min_x
                 y += max_y
                 attributes['transform'] = 'translate({},{})'.format(x, y)
-            attributes['font-size'] = '{}'.format(font_size)
+            attributes['font-size'] = '{}'.format(font_size * self.scale)
             attributes['style'] = 'fill:{}'.format(color)
 
             # Create node

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -738,12 +738,22 @@ class WordCloud(object):
         Font is assumed to be available to the SVG reader. Otherwise, text
         coordinates may produce artifacts when rendered with replacement font.
         It is also possible to include a subset of the original font in WOFF
-        format using `embed_font` (requires `fontTools`).
+        format using ``embed_font`` (requires `fontTools`).
 
         Note that some renderers do not handle glyphs the same way, and may
-        differ from `to_image` result. In particular, handwriting-like fonts
-        (e.g. Segoe Script) ligatures might not be properly rendered, which
-        could introduce discrepancies in tight layouts.
+        differ from ``to_image`` result. In particular, Complex Text Layout may
+        not be supported. In this typesetting, the shape or positioning of a
+        grapheme depends on its relation to other graphemes.
+
+        Pillow, since version 4.2.0, supports CTL using ``libraqm``. However,
+        due to dependencies, this feature is not always enabled. Hence, the
+        same rendering differences may appear in ``to_image``. As this
+        rasterized output is used to compute the layout, this also affects the
+        layout generation. Use ``PIL.features.check`` to test availability of
+        ``raqm``.
+
+        Consistant rendering is therefore expected if both Pillow and the SVG
+        renderer have the same support of CTL.
 
         Contour drawing is not supported.
 
@@ -754,7 +764,7 @@ class WordCloud(object):
 
         optimize_embedded_font : bool, default=True
             Whether to be aggressive when embedding a font, to reduce size. In
-            particular, hinting tables are dropped, which may introduces slight
+            particular, hinting tables are dropped, which may introduce slight
             changes to character shapes (w.r.t. `to_image` baseline).
 
         embed_image : bool, default=False

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -761,9 +761,10 @@ class WordCloud(object):
         style = {}
         font = ImageFont.truetype(self.font_path, int(max_font_size * self.scale))
         font_family, font_style = font.getname()
-        # TODO properly escape/quote this
+        # TODO properly escape/quote this name
         # TODO should add option to specify URL for font (i.e. WOFF file)
         # TODO should maybe add option to embed font in SVG file
+        # TODO when embedding, we should try to embed only a subset
         style['font-family'] = repr(font_family)
         font_style = font_style.lower()
         if 'bold' in font_style:
@@ -801,14 +802,15 @@ class WordCloud(object):
         for (word, count), font_size, (y, x), orientation, color in self.layout_:
             x *= self.scale
             y *= self.scale
-
+            
             # Get text metrics
             font = ImageFont.truetype(self.font_path, int(font_size * self.scale))
             (size_x, size_y), (offset_x, offset_y) = font.font.getsize(word)
             ascent, descent = font.getmetrics()
 
             # Compute text bounding box
-            min_x = offset_x
+            # TODO some browser do not render glyphs the same way (e.g. Segoe Script in Chrome is different, while in Internet Explorer it matches to_image)
+            min_x = -offset_x
             max_x = size_x - offset_x
             min_y = ascent - size_y
             max_y = ascent - offset_y
@@ -829,6 +831,8 @@ class WordCloud(object):
             # Create node
             attributes = ' '.join('{}="{}"'.format(k, v) for k, v in attributes.items())
             result.append('<text {}>{}</text>'.format(attributes, word))
+
+        # TODO draw contour
 
         # Complete SVG file
         result.append('</svg>')

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -730,9 +730,23 @@ class WordCloud(object):
 
     def to_html(self):
         raise NotImplementedError("FIXME!!!")
-    
+
     def to_svg(self, embed_image=False):
         """Export to SVG.
+
+        Font is assumed to be available to the SVG reader. Otherwise, text
+        coordinates may produce artifacts when rendered with replacement font.
+
+        Note that some renderers do not handle glyphs the same way, and may
+        differ from `to_image` result. In particular, handwriting-like fonts
+        (e.g. Segoe Script) ligatures might not be properly rendered, which
+        could introduce discrepancies in tight layouts.
+
+        Parameters
+        ----------
+        embed_image : bool, default=False
+            Whether to include rasterized image inside resulting SVG file.
+            Useful for debugging.
 
         Returns
         -------
@@ -799,7 +813,7 @@ class WordCloud(object):
                 '</rect>'
                 .format(self.background_color)
             )
-        
+
         # Embed image, useful for debug purpose
         if embed_image:
             image = self.to_image()
@@ -819,17 +833,15 @@ class WordCloud(object):
         for (word, count), font_size, (y, x), orientation, color in self.layout_:
             x *= self.scale
             y *= self.scale
-            
+
             # Get text metrics
             font = ImageFont.truetype(self.font_path, int(font_size * self.scale))
             (size_x, size_y), (offset_x, offset_y) = font.font.getsize(word)
             ascent, descent = font.getmetrics()
 
             # Compute text bounding box
-            # TODO some browser do not render glyphs the same way (e.g. Segoe Script in Chrome is different, while in Internet Explorer it matches to_image)
             min_x = -offset_x
             max_x = size_x - offset_x
-            min_y = ascent - size_y
             max_y = ascent - offset_y
 
             # Compute text attributes


### PR DESCRIPTION
This is another tentative at vector file export. I initially did some experiments using [freetype-py](https://pypi.org/project/freetype-py/), but I was able to get the same results using Pillow bindings of FreeType (there are [inconsistencies](https://stackoverflow.com/questions/43060479/how-to-get-the-font-pixel-height-using-pil-imagefont), though).

There are however slight mismatches between rasterized and vector outputs. I also spotted inconsistencies using different browsers for some fonts (e.g. Segoe Script). I added an option (`embed_image`) to include the output of `to_image` in the SVG file, which is useful for debugging. I believe most differences are due to subtleties in kerning and ligatures, which is not significant in common fonts.

It may also be useful to consider embedding the font file directly in the SVG file (or only the required subset, ideally). As my personal use case does not require fancy fonts, I did not dig any further on this topic. This means that using the default font will render properly only if Droid Sans Mono is available to the SVG reader.

I have attached [two modified examples](https://github.com/amueller/word_cloud/files/3999068/examples.zip), which use different fonts for portability.

Also, contour is not implemented.

Last but not least, I want to credit @jnothman and [his pull request](https://github.com/amueller/word_cloud/pull/163) (in particular, his hack to detect font name/weight/style). As I am not fluent in forks and pull requests, I had to create a new pull request. But I would be glad to learn how to extend an existing pull request!