### PR TITLE
Increase the small canvas size to avoid fallback to fail

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -361,7 +361,7 @@ def test_tiny_canvas():
     w = WordCloud(max_words=50, width=1, height=1)
     with pytest.raises(ValueError, match="Couldn't find space to draw"):
         w.generate(THIS)
-        assert len(w.layout_) == 0
+    assert len(w.layout_) == 0
 
 
 def test_coloring_black_works():

--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -351,7 +351,9 @@ def test_recolor_too_small_set_default():
 
 def test_small_canvas():
     # check font size fallback works on small canvas
-    WordCloud(max_words=50, width=20, height=20).generate(THIS)
+    wc = WordCloud(max_words=50, width=21, height=21)
+    wc.generate(THIS)
+    assert len(wc.layout_) == 1
 
 
 def test_tiny_canvas():
@@ -359,6 +361,7 @@ def test_tiny_canvas():
     w = WordCloud(max_words=50, width=1, height=1)
     with pytest.raises(ValueError, match="Couldn't find space to draw"):
         w.generate(THIS)
+        assert len(w.layout_) == 0
 
 
 def test_coloring_black_works():


### PR DESCRIPTION
This is a bug fix in small canvas tests where the fallback behaviors are tested when only one (or zero) word fits within the canvas. The word placement has a random component, and `test_small_canvas` occasionally fails to find a placement for a word before its font size goes below the minimum font size allowed. 

This fix increases the small canvas size by one pixel to avoid that edge case to occur. The two small canvas tests also explicitly tests for the number of elements in `WordCloud.layout_`, which basically determines the fallback behavior.