### PR TITLE
Fix #528: make bigram generation stopword aware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+To contribute to wordcloud, you'll need to follow the instructions in
+[Creating a pull request from a fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+
+In addition to the general procedure for creating a pull request, please follow
+the following steps:
+
+## Before starting development
+
+### Use a correct version of Python
+
+Python 3.7.x should be fine for development.
+
+```
+python --version
+> Python 3.7.6
+```
+
+### Install all dependencies
+
+pip install -U -r requirements.txt -r requirements-dev.txt
+
+### Ensure that files are correctly formatted
+
+```
+flake8
+```
+
+### Ensure that tests pass
+
+```
+pip install -e .
+pytest
+```
+
+## Before creating a pull request
+
+### Confirm formatting and test passage
+
+```
+flake8
+pytest
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ python --version
 
 ### Install all dependencies
 
+```
 pip install -U -r requirements.txt -r requirements-dev.txt
+```
 
 ### Ensure that files are correctly formatted
 

--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -54,10 +54,10 @@ better late than never someone will say
 
 
 def test_collocations():
-    wc = WordCloud(collocations=False, stopwords=[])
+    wc = WordCloud(collocations=False, stopwords=set())
     wc.generate(THIS)
 
-    wc2 = WordCloud(collocations=True, stopwords=[])
+    wc2 = WordCloud(collocations=True, stopwords=set())
     wc2.generate(THIS)
 
     assert "is better" in wc2.words_
@@ -66,13 +66,15 @@ def test_collocations():
 
 
 def test_collocation_stopwords():
-    wc = WordCloud(collocations=True, stopwords={"you", "very"})
+    wc = WordCloud(collocations=True, stopwords={"you", "very"}, collocation_threshold=9)
     wc.generate(STOPWORDED_COLLOCATIONS)
 
     assert "thank you" in wc.words_
     assert "very much" in wc.words_
-    assert "thank" in wc.words_
-    assert "thank much" not in wc.words_
+    # "thank" will have been removed in favor of the bigrams including "thank"
+    assert "thank" not in wc.words_
+    # a bigram of all stopwords will be removed
+    assert "you very" not in wc.words_
 
 
 def test_plurals_numbers():

--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -41,6 +41,17 @@ Namespaces are one honking great idea -- let's do more of those!
     46 09 55 05 82   23 17 25 35 94   08 128
 """
 
+STOPWORDED_COLLOCATIONS = """
+thank you very much
+thank you very much
+thank you very much
+thanks
+"""
+
+SMALL_CANVAS = """
+better late than never someone will say
+"""
+
 
 def test_collocations():
     wc = WordCloud(collocations=False, stopwords=[])
@@ -52,6 +63,16 @@ def test_collocations():
     assert "is better" in wc2.words_
     assert "is better" not in wc.words_
     assert "way may" not in wc2.words_
+
+
+def test_collocation_stopwords():
+    wc = WordCloud(collocations=True, stopwords={"you", "very"})
+    wc.generate(STOPWORDED_COLLOCATIONS)
+
+    assert "thank you" in wc.words_
+    assert "very much" in wc.words_
+    assert "thank" in wc.words_
+    assert "thank much" not in wc.words_
 
 
 def test_plurals_numbers():
@@ -352,8 +373,8 @@ def test_recolor_too_small_set_default():
 def test_small_canvas():
     # check font size fallback works on small canvas
     wc = WordCloud(max_words=50, width=21, height=21)
-    wc.generate(THIS)
-    assert len(wc.layout_) == 1
+    wc.generate(SMALL_CANVAS)
+    assert len(wc.layout_) > 0
 
 
 def test_tiny_canvas():

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -273,6 +273,14 @@ class WordCloud(object):
     min_word_length : int, default=0
         Minimum number of letters a word must have to be included.
 
+    collocation_threshold: int, default=30
+        Bigrams must have a Dunning likelihood collocation score greater than this
+        parameter to be counted as bigrams. Default of 30 is arbitrary.
+
+        See Manning, C.D., Manning, C.D. and Schütze, H., 1999. Foundations of
+        Statistical Natural Language Processing. MIT press, p. 162
+        https://nlp.stanford.edu/fsnlp/promo/colloc.pdf#page=22
+
     Attributes
     ----------
     ``words_`` : dict of string to float
@@ -303,7 +311,7 @@ class WordCloud(object):
                  relative_scaling='auto', regexp=None, collocations=True,
                  colormap=None, normalize_plurals=True, contour_width=0,
                  contour_color='black', repeat=False,
-                 include_numbers=False, min_word_length=0):
+                 include_numbers=False, min_word_length=0, collocation_threshold=30):
         if font_path is None:
             font_path = FONT_PATH
         if color_func is None and colormap is None:
@@ -354,6 +362,7 @@ class WordCloud(object):
         self.repeat = repeat
         self.include_numbers = include_numbers
         self.min_word_length = min_word_length
+        self.collocation_threshold = collocation_threshold
 
     def fit_words(self, frequencies):
         """Create a word_cloud from words and frequencies.
@@ -574,7 +583,7 @@ class WordCloud(object):
 
         stopwords = set([i.lower() for i in self.stopwords])
         if self.collocations:
-            word_counts = unigrams_and_bigrams(words, stopwords, self.normalize_plurals)
+            word_counts = unigrams_and_bigrams(words, stopwords, self.normalize_plurals, self.collocation_threshold)
         else:
             # remove stopwords
             words = [word for word in words if word.lower() not in stopwords]

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -557,15 +557,11 @@ class WordCloud(object):
         include all those things.
         """
 
-        stopwords = set([i.lower() for i in self.stopwords])
-
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode  # noqa: F821
                  else 0)
         regexp = self.regexp if self.regexp is not None else r"\w[\w']+"
 
         words = re.findall(regexp, text, flags)
-        # remove stopwords
-        words = [word for word in words if word.lower() not in stopwords]
         # remove 's
         words = [word[:-2] if word.lower().endswith("'s") else word
                  for word in words]
@@ -576,9 +572,12 @@ class WordCloud(object):
         if self.min_word_length:
             words = [word for word in words if len(word) >= self.min_word_length]
 
+        stopwords = set([i.lower() for i in self.stopwords])
         if self.collocations:
-            word_counts = unigrams_and_bigrams(words, self.normalize_plurals)
+            word_counts = unigrams_and_bigrams(words, stopwords, self.normalize_plurals)
         else:
+            # remove stopwords
+            words = [word for word in words if word.lower() not in stopwords]
             word_counts, _ = process_tokens(words, self.normalize_plurals)
 
         return word_counts

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Author: Andreas Christian Mueller <t3kcit@gmail.com>
 #
 # (c) 2012


### PR DESCRIPTION
I was a little confused on the logic of `test_wordcloud.py::test_small_canvas`, and this fix broke it.  I think my update to it is logical, but I'm not 100% sure what the logic of asserting a single `layout_` element was.