### PR TITLE
requirements: Address pytest regression installing pytest<5.4.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ codecov
 coverage
 flake8
 mock
-pytest
+pytest<5.4.0
 pytest-cov
 pytest-sugar
 setuptools>=28.0.0


### PR DESCRIPTION
The version 5.4.0 of pytest introduced a regression preventing pytest-sugar
from working (see [1] and [2])

It has been fixed in pytest (see [3]) and waiting a new release of
pytest is published, this commit updates requirements.

[1] https://github.com/Teemu/pytest-sugar/issues/187
[2] https://github.com/amueller/word_cloud/pull/535#issuecomment-611041477
[3] https://github.com/pytest-dev/pytest/pull/6986