### PR TITLE
ci: Explicitly use manylinux1 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,12 @@ references:
 
   x64_build_job: &x64_build_job
     docker:
-      - image: dockcross/manylinux-x64
+      - image: dockcross/manylinux1-x64
     <<: *ci_steps
 
   x86_build_job: &x86_build_job
     docker:
-      - image: dockcross/manylinux-x86
+      - image: dockcross/manylinux1-x86
     <<: *ci_steps
 
   deploy_website_command: &deploy_website_command

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest-cov
 pytest-sugar
 setuptools>=28.0.0
 twine
-wheel==0.31.1
+wheel==0.34.1


### PR DESCRIPTION
Following the introduction of other version of manylinux2010 and manulinux2014,
the image manylinux dockcross image has been abandoned in favor of manylinux1
image.