### PR TITLE
write image to stdout by default

### DIFF
--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -140,7 +140,7 @@ def test_unicode_with_stopwords():
     assert u'\u304D' in args['stopwords']
 
 
-def test_cli_writes_image(tmpdir, tmp_text_file):
+def test_cli_writes_to_imagefile(tmpdir, tmp_text_file):
     # ensure writing works with all python versions
     tmp_image_file = tmpdir.join("word_cloud.png")
 
@@ -149,8 +149,19 @@ def test_cli_writes_image(tmpdir, tmp_text_file):
     args, text, image_file = cli.parse_args(['--text', str(tmp_text_file), '--imagefile', str(tmp_image_file)])
     cli.main(args, text, image_file)
 
-    # expecting image to be written
+    # expecting image to be written to imagefile
     assert tmp_image_file.size() > 0
+
+
+def test_cli_writes_to_stdout(tmp_text_file, capsysbinary):
+    tmp_text_file.write(b'some text')
+
+    args, text, image_file = cli.parse_args(['--text', str(tmp_text_file)])
+    cli.main(args, text, image_file)
+
+    # expecting image to be written to stdout
+    out, _ = capsysbinary.readouterr()
+    assert len(str(out)) > 0
 
 
 def test_cli_regexp(tmp_text_file):

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -162,7 +162,7 @@ def test_cli_writes_to_stdout(tmpdir, tmp_text_file):
     tmp_text_file.write(b'some text')
 
     originalBuffer = sys.stdout.buffer
-    sys.stdout.buffer = open(tmp_image_file, 'wb+')
+    sys.stdout.buffer = tmp_image_file.open('wb+')
 
     args, text, image_file = cli.parse_args(['--text', str(tmp_text_file)])
     cli.main(args, text, image_file)

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+import sys
 from collections import namedtuple
 
 import wordcloud as wc
@@ -153,15 +154,23 @@ def test_cli_writes_to_imagefile(tmpdir, tmp_text_file):
     assert tmp_image_file.size() > 0
 
 
-def test_cli_writes_to_stdout(tmp_text_file, capsysbinary):
+# capsysbinary should be used here, but it's not supported in python 2.
+def test_cli_writes_to_stdout(tmpdir, tmp_text_file):
+    # ensure writing works with all python versions
+    tmp_image_file = tmpdir.join("word_cloud.png")
+
     tmp_text_file.write(b'some text')
+
+    originalBuffer = sys.stdout.buffer
+    sys.stdout.buffer = open(tmp_image_file, 'wb+')
 
     args, text, image_file = cli.parse_args(['--text', str(tmp_text_file)])
     cli.main(args, text, image_file)
 
+    sys.stdout.buffer = originalBuffer
+
     # expecting image to be written to stdout
-    out, _ = capsysbinary.readouterr()
-    assert len(str(out)) > 0
+    assert tmp_image_file.size() > 0
 
 
 def test_cli_regexp(tmp_text_file):

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -90,11 +90,8 @@ def main(args, text, imagefile):
     wordcloud.generate(text)
     image = wordcloud.to_image()
 
-    try:
+    with imagefile:
         image.save(imagefile, format='png', optimize=True)
-    finally:
-        if imagefile != sys.stdout.buffer:
-            imagefile.close()
 
 
 def make_parser():

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -54,14 +54,15 @@ class FileType(object):
             if 'r' in self._mode:
                 return sys.stdin
             elif 'w' in self._mode:
-                return sys.stdout
+                return sys.stdout.buffer if 'b' in self._mode else sys.stdout
             else:
                 msg = 'argument "-" with mode %r' % self._mode
                 raise ValueError(msg)
 
         # all other arguments are used as file names
         try:
-            return io.open(string, self._mode, self._bufsize, encoding="UTF-8")
+            encoding = None if 'b' in self._mode else "UTF-8"
+            return io.open(string, self._mode, self._bufsize, encoding=encoding)
         except IOError as e:
             message = "can't open '%s': %s"
             raise argparse.ArgumentTypeError(message % (string, e))
@@ -107,7 +108,7 @@ def make_parser():
         help='specify file of stopwords (containing one word per line)'
              ' to remove from the given text after parsing')
     parser.add_argument(
-        '--imagefile', metavar='file', type=argparse.FileType('wb'),
+        '--imagefile', metavar='file', type=FileType('wb'),
         default='-',
         help='file the completed PNG image should be written to'
              ' (default: stdout)')

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -90,8 +90,11 @@ def main(args, text, imagefile):
     wordcloud.generate(text)
     image = wordcloud.to_image()
 
-    with imagefile:
+    try:
         image.save(imagefile, format='png', optimize=True)
+    finally:
+        if imagefile != sys.stdout.buffer:
+            imagefile.close()
 
 
 def make_parser():


### PR DESCRIPTION
Pretty simple commit. Fixes: #451, #445 

Reading this ticket helped a bit https://bugs.python.org/issue14156

Line 57 was taken from the official `argparse` lib, in order to toggle between `sys.stdout` and `sys.stdout.buffer`, based on the mode
https://github.com/python/cpython/blob/b47950f8ce4d06d6a7dd8e2c8c0c704d4972be01/Lib/argparse.py#L1191

Line 64 & 65 are to fix the error caused by line 111
`ValueError: binary mode doesn't take an encoding argument`

line 111 switches `argparse.FileType` to your custom `FileType`.

Examples:
```sh
# current usage
$ wordcloud_cli --text ./text.txt --imagefile ./test.png

# explicitly write to stdout
$ wordcloud_cli --text ./text.txt --imagefile - > ./test.png

# implicitly write to stdout
$ wordcloud_cli --text ./text.txt > ./test.png
```