### PR TITLE
Specify encoding in parrot.py example

### DIFF
--- a/examples/parrot.py
+++ b/examples/parrot.py
@@ -19,7 +19,7 @@ from wordcloud import WordCloud, ImageColorGenerator
 d = os.path.dirname(__file__) if "__file__" in locals() else os.getcwd()
 
 # load wikipedia text on rainbow
-text = open(os.path.join(d, 'wiki_rainbow.txt')).read()
+text = open(os.path.join(d, 'wiki_rainbow.txt'), encoding="utf-8").read()
 
 # load image. This has been modified in gimp to be brighter and have more saturation.
 parrot_color = np.array(Image.open(os.path.join(d, "parrot-by-jose-mari-gimenez2.jpg")))


### PR DESCRIPTION
I needed this to fix
```
Traceback (most recent call last):
  File "parrot.py", line 22, in <module>
    text = open(os.path.join(d, 'wiki_rainbow.txt')).read()
  File "F:\Programme\Programme\Anaconda3\envs\textrecognition\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 33225: character maps to <undefined>
```
on windows, in python 3.7.3