### PR TITLE
regex change to address issue #495

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -327,6 +327,20 @@ def test_process_text():
     assert isinstance(result, dict)
 
 
+def test_process_text_default_patterns():
+    wc = WordCloud(stopwords=set(), include_numbers=True, min_word_length=2)
+    words = wc.process_text(THIS)
+
+    wc2 = WordCloud(stopwords=set(), include_numbers=True, min_word_length=1)
+    words2 = wc2.process_text(THIS)
+
+    assert "a" not in words
+    assert "3" not in words
+
+    assert "a" in words2
+    assert "3" in words2
+
+
 def test_process_text_regexp_parameter():
     # test that word processing is influenced by `regexp`
     wc = WordCloud(max_words=50, regexp=r'\w{5}')

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -569,7 +569,7 @@ class WordCloud(object):
 
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode  # noqa: F821
                  else 0)
-        regexp = self.regexp if self.regexp is not None else r"\w[\w']+"
+        regexp = self.regexp if self.regexp is not None else r"\w[\w']*"
 
         words = re.findall(regexp, text, flags)
         # remove 's

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -569,7 +569,8 @@ class WordCloud(object):
 
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode  # noqa: F821
                  else 0)
-        regexp = self.regexp if self.regexp is not None else r"\w[\w']*"
+        pattern = r"\w[\w']*" if self.min_word_length <= 1 else r"\w[\w']+"
+        regexp = self.regexp if self.regexp is not None else pattern
 
         words = re.findall(regexp, text, flags)
         # remove 's


### PR DESCRIPTION
Changed r"\w[\w']+" to r"\w[\w']*" so that single words are matched too, as per issue #495.  
Note: the user will need to be mindful that single letters words such as 'a' and 'i' will not appear if the default stopword list is used.