### PR TITLE
Feature: to_html implemented

### DIFF
--- a/examples/a_new_hope_to_html.py
+++ b/examples/a_new_hope_to_html.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+Using custom colors
+===================
+
+Using the recolor method and custom coloring functions.
+"""
+
+import numpy as np
+from PIL import Image
+from os import path
+import matplotlib.pyplot as plt
+import os
+import random
+
+from wordcloud import WordCloud, STOPWORDS
+
+
+def grey_color_func(word, font_size, position, orientation, random_state=None,
+                    **kwargs):
+    return "hsl(0, 0%%, %d%%)" % random.randint(60, 100)
+
+
+# get data directory (using getcwd() is needed to support running example in generated IPython notebook)
+d = path.dirname(__file__) if "__file__" in locals() else os.getcwd()
+
+# read the mask image taken from
+# http://www.stencilry.org/stencils/movies/star%20wars/storm-trooper.gif
+mask = np.array(Image.open(path.join(d, "stormtrooper_mask.png")))
+
+# movie script of "a new hope"
+# http://www.imsdb.com/scripts/Star-Wars-A-New-Hope.html
+# May the lawyers deem this fair use.
+text = open(path.join(d, 'a_new_hope.txt')).read()
+
+# pre-processing the text a little bit
+text = text.replace("HAN", "Han")
+text = text.replace("LUKE'S", "Luke")
+
+# adding movie script specific stopwords
+stopwords = set(STOPWORDS)
+stopwords.add("int")
+stopwords.add("ext")
+
+wc = WordCloud(max_words=1000, mask=mask, stopwords=stopwords, margin=10,
+               random_state=1)
+wc.generate(text)
+# wc.to_html(type='canvas', file_path='a_new_hope10.html')
+# now supported ('svg', 'canvas')
+wc.to_html(type='svg', file_path='a_new_hope_svg.html')
+wc.to_html(type='canvas', file_path='a_new_hope_canvas.html')
+# store default colored image
+default_colors = wc.to_array()
+plt.title("Custom colors")
+plt.imshow(wc.recolor(color_func=grey_color_func, random_state=3),
+           interpolation="bilinear")
+wc.to_file("a_new_hope.png")
+plt.axis("off")
+plt.figure()
+plt.title("Default colors")
+plt.imshow(default_colors, interpolation="bilinear")
+plt.axis("off")
+plt.show()

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -101,6 +101,7 @@ class colormap_color_func(object):
     >>> WordCloud(color_func=colormap_color_func("magma"))
 
     """
+
     def __init__(self, colormap):
         import matplotlib.pyplot as plt
         self.colormap = plt.cm.get_cmap(colormap)
@@ -148,6 +149,7 @@ def get_single_color_func(color):
         r, g, b = colorsys.hsv_to_rgb(h, s, random_state.uniform(0.2, 1))
         return 'rgb({:.0f}, {:.0f}, {:.0f})'.format(r * rgb_max, g * rgb_max,
                                                     b * rgb_max)
+
     return single_color_func
 
 
@@ -774,7 +776,7 @@ class WordCloud(object):
 
         # write to file
         if file_path != None:
-            with open(file_path, "w+",encoding='utf-8') as html_file:
+            with open(file_path, "w+", encoding='utf-8') as html_file:
                 html_file.write(html_string)
 
         return html_string
@@ -797,12 +799,12 @@ class WordCloud(object):
            """
         font = ImageFont.truetype(self.font_path)
         font_family, raw_font_style = font.getname()
-        html_string = svg_html_template.format(font_family,repr(self.font_path),self.to_svg())
+        html_string = svg_html_template.format(font_family, repr(self.font_path), self.to_svg())
         return html_string
 
     def to_html_canvas(self):
-        # TODO: to canvas
 
+        # TODO: format("truetype") compatibility issues?
         # formate(font-family_name , font-path , width, height,font-family_name, canvas_draw_result)
         html_template = """
              <!DOCTYPE html>
@@ -865,7 +867,15 @@ class WordCloud(object):
             """
 
         result = []
-
+        # Add background
+        if self.background_color is not None:
+            result.append(
+                """
+                    ctx.fillStyle = "{}";
+                    ctx.fillRect(0, 0, c.width, c.height);
+                """
+                    .format(self.background_color)
+            )
 
         # {text_style} {size} {font_style}
         # {color}
@@ -877,9 +887,6 @@ class WordCloud(object):
                 ctx.rotate({});
                 ctx.fillText("{}", {}, {});
             """
-
-
-
 
         for (word, count), font_size, (y, x), orientation, color in self.layout_:
             x *= self.scale
@@ -923,8 +930,8 @@ class WordCloud(object):
                 "ctx.rotate(90 * Math.PI / 180);" if orientation == Image.ROTATE_90 else "")
 
         return html_template.format(
-            font_family, repr(self.font_path),self.width,self.height,
-            font_family,'\n'.join(result)
+            font_family, repr(self.font_path), self.width, self.height,
+            font_family, '\n'.join(result)
         )
 
     def to_svg(self, embed_font=False, optimize_embedded_font=True, embed_image=False):
@@ -1018,7 +1025,7 @@ class WordCloud(object):
             ' height="{}"'
             ' font-family="{}"'
             '>'
-            .format(
+                .format(
                 width * self.scale,
                 height * self.scale,
                 font_family
@@ -1027,7 +1034,6 @@ class WordCloud(object):
 
         # Embed font, if requested
         if embed_font:
-
             # Import here, to avoid hard dependency on fonttools
             import fontTools
             import fontTools.subset
@@ -1075,7 +1081,7 @@ class WordCloud(object):
                 'src:url("{}")format("woff");'
                 '}}'
                 '</style>'
-                .format(
+                    .format(
                     font_family,
                     font_weight,
                     font_style,
@@ -1092,7 +1098,7 @@ class WordCloud(object):
             'font-style:{};'
             '}}'
             '</style>'
-            .format(
+                .format(
                 font_family,
                 font_weight,
                 font_style
@@ -1108,7 +1114,7 @@ class WordCloud(object):
                 ' style="fill:{}"'
                 '>'
                 '</rect>'
-                .format(self.background_color)
+                    .format(self.background_color)
             )
 
         # Embed image, useful for debug purpose
@@ -1123,7 +1129,7 @@ class WordCloud(object):
                 ' height="100%"'
                 ' href="data:image/jpg;base64,{}"'
                 '/>'
-                .format(data)
+                    .format(data)
             )
 
         # For each word in layout
@@ -1162,7 +1168,7 @@ class WordCloud(object):
                 '>'
                 '{}'
                 '</text>'
-                .format(
+                    .format(
                     transform,
                     font_size * self.scale,
                     color,

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -101,7 +101,6 @@ class colormap_color_func(object):
     >>> WordCloud(color_func=colormap_color_func("magma"))
 
     """
-
     def __init__(self, colormap):
         import matplotlib.pyplot as plt
         self.colormap = plt.cm.get_cmap(colormap)
@@ -149,7 +148,6 @@ def get_single_color_func(color):
         r, g, b = colorsys.hsv_to_rgb(h, s, random_state.uniform(0.2, 1))
         return 'rgb({:.0f}, {:.0f}, {:.0f})'.format(r * rgb_max, g * rgb_max,
                                                     b * rgb_max)
-
     return single_color_func
 
 
@@ -1074,7 +1072,7 @@ class WordCloud(object):
             ' height="{}"'
             ' font-family="{}"'
             '>'
-                .format(
+            .format(
                 width * self.scale,
                 height * self.scale,
                 font_family
@@ -1083,6 +1081,7 @@ class WordCloud(object):
 
         # Embed font, if requested
         if embed_font:
+
             # Import here, to avoid hard dependency on fonttools
             import fontTools
             import fontTools.subset
@@ -1130,7 +1129,7 @@ class WordCloud(object):
                 'src:url("{}")format("woff");'
                 '}}'
                 '</style>'
-                    .format(
+                .format(
                     font_family,
                     font_weight,
                     font_style,
@@ -1147,7 +1146,7 @@ class WordCloud(object):
             'font-style:{};'
             '}}'
             '</style>'
-                .format(
+            .format(
                 font_family,
                 font_weight,
                 font_style
@@ -1163,7 +1162,7 @@ class WordCloud(object):
                 ' style="fill:{}"'
                 '>'
                 '</rect>'
-                    .format(self.background_color)
+                .format(self.background_color)
             )
 
         # Embed image, useful for debug purpose
@@ -1178,7 +1177,7 @@ class WordCloud(object):
                 ' height="100%"'
                 ' href="data:image/jpg;base64,{}"'
                 '/>'
-                    .format(data)
+                .format(data)
             )
 
         # For each word in layout
@@ -1217,7 +1216,7 @@ class WordCloud(object):
                 '>'
                 '{}'
                 '</text>'
-                    .format(
+                .format(
                     transform,
                     font_size * self.scale,
                     color,

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -969,9 +969,8 @@ class WordCloud(object):
 
         # Get font information
         font = ImageFont.truetype(self.font_path, int(max_font_size * self.scale))
-        raw_font_family, raw_font_style = font.getname()
-        # TODO properly escape/quote this name?
-        font_family = repr(raw_font_family)
+
+        font_family, raw_font_style = font.getname()
         # TODO better support for uncommon font styles/weights?
         raw_font_style = raw_font_style.lower()
         if 'bold' in raw_font_style:
@@ -991,10 +990,12 @@ class WordCloud(object):
             ' xmlns="http://www.w3.org/2000/svg"'
             ' width="{}"'
             ' height="{}"'
+            ' font-family="{}"'
             '>'
             .format(
                 width * self.scale,
-                height * self.scale
+                height * self.scale,
+                font_family
             )
         )
 

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -786,12 +786,15 @@ class WordCloud(object):
             """
            <!DOCTYPE html>
            <html>
-           <style>
+           <head>
+          <style>
             @font-face {{
-                      font-family: {};
-                      src: url({}) format("truetype");
+                font-family: {font_family};
+                {font_face_src}
                 }}
             </style>
+           </head>
+
            <body>
               {}
            </body>
@@ -799,13 +802,32 @@ class WordCloud(object):
            """
         font = ImageFont.truetype(self.font_path)
         font_family, raw_font_style = font.getname()
-        html_string = svg_html_template.format(font_family, repr(self.font_path), self.to_svg())
+        # TODO: compability issue: work fine in chrome , bad in firefox
+        font_face_src = {
+            "eot": "src: url({font_path}); /* IE9 Compat Modes */ \n"
+                   + "src: url({font_path}) format('embedded-opentype'); /* IE6-IE8 */".format(
+                font_path=repr(self.font_path)),
+            "otf": "src: url({font_path}) format('opentype');  /* for open type */".format(
+                font_path=repr(self.font_path)),
+            "ttf": "src: url({font_path})  format('truetype'); /* Safari, Android, iOS */".format(
+                font_path=repr(self.font_path)),
+            "woff2": "src: url({font_path}) format('woff2'); /* Super Modern Browsers */".format(
+                font_path=repr(self.font_path)),
+            "woff": "src: url({font_path}) format('woff'); /* Pretty Modern Browsers */".format(
+                font_path=repr(self.font_path)),
+            "svg": "src: url({font_path}) format('svg'); /* Legacy iOS */".format(font_path=repr(self.font_path)),
+        }
+        # get font type name
+        font_family_path = os.path.basename(self.font_path)
+        # font_family = font_family_path[:font_family_path.find(".")]
+        font_type_suffix = font_family_path[font_family_path.find(".") + 1:]
+
+        html_string = svg_html_template.format(self.to_svg(),font_face_src=font_face_src[font_type_suffix],font_family=font_family)
         return html_string
 
     def to_html_canvas(self):
 
         # TODO: format("truetype") compatibility issues?
-        # formate(font-family_name , font-path , width, height,font-family_name, canvas_draw_result)
         html_template = """
              <!DOCTYPE html>
             <html>
@@ -895,11 +917,11 @@ class WordCloud(object):
 
             # get font type name
             font_family_path = os.path.basename(self.font_path)
-            font_family = font_family_path[:font_family_path.find(".")]
+            # font_family = font_family_path[:font_family_path.find(".")]
             font_type_suffix = font_family_path[font_family_path.find(".") + 1:]
 
             # TODO better support for uncommon font styles/weights?
-            _, raw_font_style = font.getname()
+            font_family, raw_font_style = font.getname()
             raw_font_style = raw_font_style.lower()
             if 'bold' in raw_font_style:
                 font_weight = 'bold'


### PR DESCRIPTION
1. I guess there are only two type of html can be exported as, which are
- canvas (pixels graph)
- svg (vector graph)

luckily , although they are two different type of graph , canvas is transformed just the same as svg.so thanks to @jojolebarjos , I can finish part of "to_canvas" quickly with reference to his to_svg method.

Here are some differences I've found bettween canvas and svg:
1.  canvas's performance in html is much better than svg
2.  canvas won't load the font automatically, so I need to write some javascript code in my html template and put a div tag in int to load the font

2. support font family will fix the texts overlap problem in to_svg method

when I tested the to_svg method, I found there are some text overllaped together , but after I add a font family attribute , the problem is gone

3.. some problems
- the font load mechanism I am using might have some compability issues, but I am pretty sure it worked well in chrome and miscrosoft edge 
- there's a a lot repeat code fragment in to_svg and to_canvas methods , may need a refactoring here  