### PR TITLE
Fix minor bug in example

### DIFF
--- a/examples/frequency.py
+++ b/examples/frequency.py
@@ -25,7 +25,7 @@ def getFrequencyDictForText(sentence):
     for text in sentence.split(" "):
         if re.match("a|the|an|the|to|in|for|of|or|by|with|is|on|that|be", text):
             continue
-        val = tmpDict.get(text, 0)
+        val = tmpDict.get(text.lower(), 0)
         tmpDict[text.lower()] = val + 1
     for key in tmpDict:
         fullTermsDict.add(key, tmpDict[key])


### PR DESCRIPTION
When `text` contains capital characters, this will refresh the dict count to 0 by finding no key. Just a minor fix.