### PR TITLE
Fixed random location range

### DIFF
--- a/wordcloud/query_integral_image.pyx
+++ b/wordcloud/query_integral_image.pyx
@@ -23,7 +23,7 @@ def query_integral_image(unsigned int[:,:] integral_image, int size_x, int
         # no room left
         return None
     # pick a location at random
-    cdef int goal = random_state.randint(0, hits)
+    cdef int goal = random_state.randint(1, hits)
     hits = 0
     for i in xrange(x - size_x):
         for j in xrange(y - size_y):


### PR DESCRIPTION
Please correct me if I am wrong: `Random.randint(a,b)` is `[a,b]` inclusive, while a valid location is `[1,hits]`.

This bug may miss a few valid positions when `goal` is 0, especially likely when`hits` is small.

