### PR TITLE
[MNT] - Update README for list of tested python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ word_cloud
 A little word cloud generator in Python. Read more about it on the [blog
 post][blog-post] or the [website][website].
 
-The code is tested against Python 2.7, 3.4, 3.5, 3.6 and 3.7.
+The code is tested against Python 3.7, 3.8, 3.9, 3.10, 3.11.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ If you are using conda, you can install from the `conda-forge` channel:
 
 #### Installation notes
 
-wordcloud depends on `numpy` and `pillow`.
-
-To save the wordcloud into a file, `matplotlib` can also be installed. See [examples](#examples) below.
+wordcloud depends on `numpy`, `pillow`, and `matplotlib`.
 
 If there are no wheels available for your version of python, installing the
 package requires having a C compiler set up. Before installing a compiler, report


### PR DESCRIPTION
The README is a bit out of date with the current tested versions, and in the current version implies that the module still is tested on / supports Python2, which I think is no longer the case (?). This update lists the current set of tested Python versions, drawing from the Github actions file.

In addition, there is a minor update to the install section of the README to note that matplotlib is now a required dependency (it previously stated it was optional, but I believe this is outdated). 