### PR TITLE
Fix test failures and deprecated Pillow functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     name: "Build aarch64 ${{ matrix.pyver }}"
     strategy:
       matrix:
-        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310]
+        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
       fail-fast: false
     runs-on: ubuntu-latest
     env:

--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -239,13 +239,13 @@ def test_mask():
     # check that using an empty mask is equivalent to not using a mask
     wc = WordCloud(random_state=42)
     wc.generate(THIS)
-    mask = np.zeros(np.array(wc).shape[:2], dtype=np.int)
+    mask = np.zeros(np.array(wc).shape[:2], dtype=int)
     wc_mask = WordCloud(mask=mask, random_state=42)
     wc_mask.generate(THIS)
     assert_array_equal(wc, wc_mask)
 
     # use actual nonzero mask
-    mask = np.zeros((234, 456), dtype=np.int)
+    mask = np.zeros((234, 456), dtype=int)
     mask[100:150, 300:400] = 255
 
     wc = WordCloud(mask=mask)
@@ -259,7 +259,7 @@ def test_mask():
 def test_mask_contour():
     # test mask contour is created, learn more at:
     # https://github.com/amueller/word_cloud/pull/348#issuecomment-370883873
-    mask = np.zeros((234, 456), dtype=np.int)
+    mask = np.zeros((234, 456), dtype=int)
     mask[100:150, 300:400] = 255
 
     sm = WordCloud(mask=mask, contour_width=1, contour_color='blue')
@@ -491,7 +491,7 @@ def test_max_font_size_as_mask_height():
     size = (default_size[0] * 2, default_size[1] * 2)
 
     # using mask, all drawable
-    mask = np.zeros(size, dtype=np.int)
+    mask = np.zeros(size, dtype=int)
     mask[:, :] = 0
     wc = WordCloud(mask=mask, random_state=42)
     wc.generate(x)

--- a/wordcloud/color_from_image.py
+++ b/wordcloud/color_from_image.py
@@ -38,11 +38,11 @@ class ImageColorGenerator(object):
         transposed_font = ImageFont.TransposedFont(font,
                                                    orientation=orientation)
         # get size of resulting text
-        box_size = transposed_font.getsize(word)
+        box_size = transposed_font.getbbox(word)
         x = position[0]
         y = position[1]
         # cut out patch under word box
-        patch = self.image[x:x + box_size[0], y:y + box_size[1]]
+        patch = self.image[x:x + box_size[2], y:y + box_size[3]]
         if patch.ndim == 3:
             # drop alpha channel if any
             patch = patch[:, :, :3]

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -505,10 +505,10 @@ class WordCloud(object):
                 transposed_font = ImageFont.TransposedFont(
                     font, orientation=orientation)
                 # get size of resulting text
-                box_size = draw.textsize(word, font=transposed_font)
+                box_size = draw.textbbox((0, 0), word, font=transposed_font, anchor="lt")
                 # find possible places using integral image:
-                result = occupancy.sample_position(box_size[1] + self.margin,
-                                                   box_size[0] + self.margin,
+                result = occupancy.sample_position(box_size[3] + self.margin,
+                                                   box_size[2] + self.margin,
                                                    random_state)
                 if result is not None or font_size < self.min_font_size:
                     # either we found a place or font-size went too small


### PR DESCRIPTION
Fixes #709 : It appeared tests were failing because of now deprecated `np.int` used in the creation of masks. It has been changed to `int` to avoid failures.

Fixes #685 #705 : as mentionned, some Pillow functions were soon deprecated, which were `textsize()` and `getsize()`. They have been changed to their counterpart `textbbox()` and `getbbox()`.

I also looked at the deprecated `plt.cm.get_cmap()` but as of now, I am not sure how to deal with it. We should use `matplotlib.colormaps[name]` or `matplotlib.colormaps.get_cmap(obj)`, but the first only deals with strings and the latter is not available in Python 3.7.