### PR TITLE
Fix matplotlib deprecation warning and adds some minor improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,17 @@ setup(
                            ["wordcloud/query_integral_image.c"])],
     entry_points={'console_scripts': ['wordcloud_cli=wordcloud.__main__:main']},
     packages=['wordcloud'],
-    package_data={'wordcloud': ['stopwords', 'DroidSansMono.ttf']}
+    package_data={'wordcloud': ['stopwords', 'DroidSansMono.ttf']},
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: Implementation :: CPython",
+    ]
 )

--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -103,7 +103,7 @@ class colormap_color_func(object):
     """
     def __init__(self, colormap):
         import matplotlib.pyplot as plt
-        self.colormap = plt.cm.get_cmap(colormap)
+        self.colormap = plt.colormaps.get_cmap(colormap)
 
     def __call__(self, word, font_size, position, orientation,
                  random_state=None, **kwargs):
@@ -576,13 +576,14 @@ class WordCloud(object):
 
         flags = (re.UNICODE if sys.version < '3' and type(text) is unicode  # noqa: F821
                  else 0)
-        pattern = r"\w[\w']*" if self.min_word_length <= 1 else r"\w[\w']+"
-        regexp = self.regexp if self.regexp is not None else pattern
+        if self.regexp is not None:
+            regexp = re.compile(self.regexp, flags)
+        else:
+            regexp = re.compile(r"\w[\w']*" if self.min_word_length <= 1 else r"\w[\w']+", flags)
 
-        words = re.findall(regexp, text, flags)
         # remove 's
         words = [word[:-2] if word.lower().endswith("'s") else word
-                 for word in words]
+                 for word in regexp.findall(text)]
         # remove numbers
         if not self.include_numbers:
             words = [word for word in words if not word.isdigit()]


### PR DESCRIPTION
- Fix deprecated matplotlib function
``` txt
test/test_wordcloud.py: 46 warnings
  wordcloud/wordcloud.py:106: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    self.colormap = plt.cm.get_cmap(colormap)
```
- Added metadata classifiers
- Improve regex performance using [re.compile](https://docs.python.org/3/library/re.html#re.compile)