### PR TITLE
MAINT Use unittest.mock instead of mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 codecov
 coverage
 flake8>=3.8.0
-mock
 pytest
 pytest-cov
 pytest-sugar

--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -8,7 +8,7 @@ import contextlib
 import wordcloud as wc
 from wordcloud import wordcloud_cli as cli
 
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 import matplotlib


### PR DESCRIPTION
The `mock` package has been deprecated for a while, use the builtin `unittest.mock` instead.