### PR TITLE
CI Cross compile arm wheels for macOS

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -6,6 +6,10 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      CIBW_TEST_SKIP: "*_arm64"
+      CIBW_ARCHS_MACOS: "x86_64 arm64"
+
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-12]


### PR DESCRIPTION
This PR uses GitHub Actions to cross compile the ARM wheels for macOS. I ran this on my fork which produce these [wheels](https://github.com/thomasjpfan/word_cloud/actions/runs/6414124168/job/17414056623):

```
  wordcloud-1.8.1.post25+gfe12554-cp310-cp310-macosx_10_9_x86_64.whl        157 kB
  wordcloud-1.8.1.post25+gfe12554-cp310-cp310-macosx_11_0_arm64.whl         152 kB
  wordcloud-1.8.1.post25+gfe12554-cp311-cp311-macosx_10_9_x86_64.whl        157 kB
  wordcloud-1.8.1.post25+gfe12554-cp311-cp311-macosx_11_0_arm64.whl         151 kB
  wordcloud-1.8.1.post25+gfe12554-cp36-cp36m-macosx_10_9_x86_64.whl         157 kB
  wordcloud-1.8.1.post25+gfe12554-cp37-cp37m-macosx_10_9_x86_64.whl         157 kB
  wordcloud-1.8.1.post25+gfe12554-cp38-cp38-macosx_10_9_x86_64.whl          157 kB
  wordcloud-1.8.1.post25+gfe12554-cp38-cp38-macosx_11_0_arm64.whl           151 kB
  wordcloud-1.8.1.post25+gfe12554-cp39-cp39-macosx_10_9_x86_64.whl          158 kB
  wordcloud-1.8.1.post25+gfe12554-cp39-cp39-macosx_11_0_arm64.whl           153 kB
  wordcloud-1.8.1.post25+gfe12554-pp37-pypy37_pp73-macosx_10_9_x86_64.whl   144 kB
  wordcloud-1.8.1.post25+gfe12554-pp38-pypy38_pp73-macosx_10_9_x86_64.whl   144 kB
  wordcloud-1.8.1.post25+gfe12554-pp39-pypy39_pp73-macosx_10_9_x86_64.whl   144 kB
```

XREF: https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile