### PR TITLE
Update cibuildwheel to build Python 3.12 wheels

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -22,7 +22,7 @@ jobs:
           git fetch --prune --unshallow
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@vv2.16.2
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
We need to update the cibuildwheel version to build Python 3.12