### PR TITLE
Add `svg` export to CLI

### DIFF
--- a/test/test_wordcloud_cli.py
+++ b/test/test_wordcloud_cli.py
@@ -153,6 +153,23 @@ def test_cli_writes_to_imagefile(tmpdir, tmp_text_file):
 
     # expecting image to be written to imagefile
     assert tmp_image_file.size() > 0
+    # assert png header
+    assert tmp_image_file.read('rb').startswith(b'\x89PNG')
+
+
+def test_cli_writes_to_svg_imagefile(tmpdir, tmp_text_file):
+    # ensure writing works with all python versions
+    tmp_image_file = tmpdir.join('word_cloud.svg')
+
+    tmp_text_file.write(b'some text')
+
+    args, text, image_file = cli.parse_args(['--text', str(tmp_text_file), '--imagefile', str(tmp_image_file)])
+    cli.main(args, text, image_file)
+
+    # expecting image to be written to imagefile
+    assert tmp_image_file.size() > 0
+    # assert svg header
+    assert tmp_image_file.read().startswith('<svg xmlns=')
 
 
 # capsysbinary should be used here, but it's not supported in python 2.

--- a/wordcloud/wordcloud_cli.py
+++ b/wordcloud/wordcloud_cli.py
@@ -88,10 +88,14 @@ class RegExpAction(argparse.Action):
 def main(args, text, imagefile):
     wordcloud = wc.WordCloud(**args)
     wordcloud.generate(text)
-    image = wordcloud.to_image()
 
     with imagefile:
-        image.save(imagefile, format='png', optimize=True)
+        if imagefile.name.endswith('.svg'):
+            image = wordcloud.to_svg()
+            imagefile.write(image.encode('utf-8'))
+        else:
+            image = wordcloud.to_image()
+            image.save(imagefile, format='png', optimize=True)
 
 
 def make_parser():
@@ -110,7 +114,7 @@ def make_parser():
     parser.add_argument(
         '--imagefile', metavar='file', type=FileType('wb'),
         default='-',
-        help='file the completed PNG image should be written to'
+        help='file the completed image should be written to'
              ' (default: stdout)')
     parser.add_argument(
         '--fontfile', metavar='path', dest='font_path',


### PR DESCRIPTION
New behaviour:
- `wordcloud_cli --imagefile img.svg --mask examples/alice_mask.png --text examples/constitution.txt`: `svg` file created

Existing behaviour:
- `wordcloud_cli --imagefile img.png --mask examples/alice_mask.png --text examples/constitution.txt`: `png` file created
- `wordcloud_cli --mask examples/alice_mask.png --text examples/constitution.txt > img.png`: `png` file created
- `wordcloud_cli --mask examples/alice_mask.png --text examples/constitution.txt > img.svg`: still creates `png` file

Resolves https://github.com/amueller/word_cloud/issues/693