### PR TITLE
Add SVG contour support to WordCloud class

### DIFF
--- a/test/test_wordcloud.py
+++ b/test/test_wordcloud.py
@@ -502,3 +502,22 @@ def test_max_font_size_as_mask_height():
 
     # Check if the biggest element has the same font size
     assert wc.layout_[0][1] == wc2.layout_[0][1]
+
+
+# test/test_wordcloud.py
+def test_svg_contour():
+    # Create a WordCloud with a contour
+    mask = np.ones((300, 300, 3), dtype=int) * 255
+    mask[100:200, 100:200, :] = 0
+
+    wc = WordCloud(contour_width=1, contour_color='blue', mask=mask, background_color='white')
+    wc.generate(THIS)
+    
+    # Convert the WordCloud to SVG
+    svg_output = wc.to_svg()
+    
+    # Check that the SVG output includes the contour path
+    assert '<path d="' in svg_output
+    assert 'fill="none"' in svg_output
+    assert 'stroke="blue"' in svg_output
+    assert 'stroke-width="1"' in svg_output


### PR DESCRIPTION
This pull request introduces the ability to generate SVG contour outlines in the WordCloud library. This feature enhances the visual representation of word clouds by providing an option to include contour outlines around the words.

**Changes include:**

1. **Modification in `wordcloud.py`**: The `to_svg` function in `wordcloud.py` has been updated to include the contour outlines if the `contour` attribute is set. The contour is converted into an SVG path command and added to the SVG output.

2. **New test function in `test_wordcloud.py`**: A new test function, `test_svg_contour`, has been added to `test_wordcloud.py`. This function tests whether the SVG output includes the contour path when the `contour` attribute is set.

These changes ensure that users can now generate word clouds with contour outlines in SVG format, providing more flexibility in the visual representation of word clouds. The added test ensures that the new feature works as expected.

Please review the changes and let me know if any adjustments are required.