### PR TITLE
Add safeguard to accept only dictionary for frequency functions

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -404,6 +404,11 @@ class WordCloud(object):
         self
 
         """
+
+        # make sure frequencies are of type dict
+        if not insanceof(frequencies, dict):
+            raise TypeError(f"Expected argument of type 'dict', but got {type(frequencies).__name__}")
+
         # make sure frequencies are sorted and normalized
         frequencies = sorted(frequencies.items(), key=itemgetter(1), reverse=True)
         if len(frequencies) <= 0:


### PR DESCRIPTION
A condition to check for dictionary in the `generate_from_frequencies` function.