### PR TITLE
Update license metadata for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Andreas Mueller", email = "t3kcit+wordcloud@gmail.com" }]
 description = "A little word cloud generator"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.7"
-license = { text = "MIT License" }
+license = "MIT"
 dependencies = ["numpy>=1.6.1", "pillow", "matplotlib"]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Problem

I think this will resolve the error reported in  #791 

## Solution

Under [PEP 639](https://peps.python.org/pep-0639/), license metadata should be expressed using [SPDX license identifiers](https://spdx.org/licenses/).
