### PR TITLE
Visualization of the word_cloud codebase

### DIFF
--- a/.codeboarding/Coloring_Strategies.md
+++ b/.codeboarding/Coloring_Strategies.md
@@ -1,0 +1,175 @@
+```mermaid
+
+graph LR
+
+    WordCloud_Core["WordCloud Core"]
+
+    Text_Tokenizer_Frequency_Counter["Text Tokenizer & Frequency Counter"]
+
+    Word_Placement_Engine["Word Placement Engine"]
+
+    Image_Drawing_Rendering["Image Drawing & Rendering"]
+
+    Coloring_Strategies["Coloring Strategies"]
+
+    Stopwords_Management["Stopwords Management"]
+
+    WordCloud_Core -- "uses" --> Word_Placement_Engine
+
+    WordCloud_Core -- "uses" --> Image_Drawing_Rendering
+
+    WordCloud_Core -- "uses" --> Coloring_Strategies
+
+    WordCloud_Core -- "uses" --> Text_Tokenizer_Frequency_Counter
+
+    Text_Tokenizer_Frequency_Counter -- "depends on" --> Stopwords_Management
+
+    Word_Placement_Engine -- "provides input to" --> Image_Drawing_Rendering
+
+    click Coloring_Strategies href "https://github.com/amueller/word_cloud/blob/main/.codeboarding//Coloring_Strategies.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This project is a Python library for generating word clouds. It consists of several interconnected components responsible for text processing, word placement, image rendering, and coloring strategies. The `WordCloud Core` acts as the central orchestrator, coordinating the activities of other components to produce the final word cloud image. Text is tokenized and frequencies are counted, with common stopwords being managed separately. Words are then strategically placed on the canvas, and their colors are determined by various strategies before being drawn onto the image. This modular design allows for clear separation of concerns and facilitates customization and maintenance of the word cloud generation process.
+
+
+
+### WordCloud Core
+
+This is the primary class and the central orchestrator of the entire word cloud generation process. It encapsulates all the configuration parameters (e.g., dimensions, font, colors, mask), manages the workflow, and provides the main interface for users to create and output word clouds. It coordinates interactions between other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L153-L1041" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud` (153:1041)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L557-L603" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud.process_text` (557:603)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L390-L555" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud.generate_from_frequencies` (390:555)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L649-L670" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud.to_image` (649:670)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L672-L712" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud.recolor` (672:712)</a>
+
+
+
+
+
+### Text Tokenizer & Frequency Counter
+
+This component is responsible for transforming raw input text into a structured format suitable for word cloud generation. It performs tasks such as tokenizing the text (splitting into words), filtering out common "stopwords," normalizing plurals, and calculating the frequency of individual words and significant two-word phrases (bigrams/collocations).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization` (0:0)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L38-L71" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization.unigrams_and_bigrams` (38:71)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L74-L137" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization.process_tokens` (74:137)</a>
+
+
+
+
+
+### Word Placement Engine
+
+This component efficiently determines the optimal, non-overlapping positions for each word on the word cloud canvas. It utilizes an "Integral Occupancy Map" data structure to quickly find available space, considering the word's size, orientation, and any specified mask.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.query_integral_image` (0:0)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L37-L66" target="_blank" rel="noopener noreferrer">`wordcloud.query_integral_image.IntegralOccupancyMap` (37:66)</a>
+
+
+
+
+
+### Image Drawing & Rendering
+
+This component handles the low-level graphical operations required to draw the words onto an image. It uses the Pillow (PIL) library to create the image canvas, load fonts, render text at specific positions and sizes, and apply rotations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.WordCloud._draw_words` (0:0)</a>
+
+
+
+
+
+### Coloring Strategies
+
+This component provides diverse methods for determining the color of each word in the word cloud. It includes functionality to derive colors directly from an input image, apply a predefined Matplotlib colormap, or assign a single, uniform color across all words. These strategies are implemented as callable functions or classes that the `WordCloud` core uses to assign colors to individual words.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/color_from_image.py#L4-L57" target="_blank" rel="noopener noreferrer">`wordcloud.color_from_image.ImageColorGenerator` (4:57)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L90-L113" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.colormap_color_func` (90:113)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L116-L150" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.get_single_color_func` (116:150)</a>
+
+
+
+
+
+### Stopwords Management
+
+This component provides a collection of common words (stopwords) that are typically filtered out during text processing. Excluding these words helps to emphasize more meaningful terms in the word cloud.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.stopwords.STOPWORDS` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Layout_Engine.md
+++ b/.codeboarding/Layout_Engine.md
@@ -1,0 +1,127 @@
+```mermaid
+
+graph LR
+
+    Word_Placement_Engine["Word Placement Engine"]
+
+    IntegralOccupancyMap["IntegralOccupancyMap"]
+
+    query_integral_image["query_integral_image"]
+
+    WordCloud_Core["WordCloud Core"]
+
+    Image_Drawing_Rendering["Image Drawing & Rendering"]
+
+    WordCloud_Core -- "uses" --> Word_Placement_Engine
+
+    Word_Placement_Engine -- "uses" --> query_integral_image
+
+    Word_Placement_Engine -- "provides input to" --> Image_Drawing_Rendering
+
+    Word_Placement_Engine -- "composed of" --> IntegralOccupancyMap
+
+    IntegralOccupancyMap -- "uses" --> query_integral_image
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Word Placement Engine is a critical component responsible for the efficient and non-overlapping arrangement of words on the word cloud canvas. Its primary purpose is to determine optimal positions for each word, ensuring visual clarity and maximizing the density of the word cloud. It achieves this through the use of an IntegralOccupancyMap data structure, which is highly optimized by leveraging a C extension (query_integral_image) for high-performance spatial queries and updates. The synergy between the IntegralOccupancyMap (providing the efficient data structure) and query_integral_image (providing the efficient algorithm) is what makes the Word Placement Engine robust and performant. Without it, generating a visually appealing and non-overlapping word cloud would be either impossible or extremely slow.
+
+
+
+### Word Placement Engine
+
+The Word Placement Engine is a critical component responsible for the efficient and non-overlapping arrangement of words on the word cloud canvas. Its primary purpose is to determine optimal positions for each word, ensuring visual clarity and maximizing the density of the word cloud. It achieves this through the use of an IntegralOccupancyMap data structure, which is highly optimized by leveraging a C extension (query_integral_image) for high-performance spatial queries and updates.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L37-L66" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.IntegralOccupancyMap` (37:66)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L1-L1" target="_blank" rel="noopener noreferrer">`wordcloud.query_integral_image` (1:1)</a>
+
+
+
+
+
+### IntegralOccupancyMap
+
+This Python class acts as the manager for the canvas's occupancy state. It maintains an "integral image" representation of the word cloud canvas, which allows for rapid calculation of sums over rectangular regions. This integral image is initialized either from a provided mask (if a shape mask is used) or as an empty canvas.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L38-L46" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.IntegralOccupancyMap:__init__` (38:46)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L48-L50" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.IntegralOccupancyMap:sample_position` (48:50)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L52-L66" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud.IntegralOccupancyMap:update` (52:66)</a>
+
+
+
+
+
+### query_integral_image
+
+This is a high-performance C extension (implemented in `query_integral_image.pyx`) that performs the actual search for a non-overlapping position within the `IntegralOccupancyMap`. It is designed for speed, as Python-level loops for such a task would be prohibitively slow for large word clouds.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L1-L1" target="_blank" rel="noopener noreferrer">`wordcloud.query_integral_image` (1:1)</a>
+
+
+
+
+
+### WordCloud Core
+
+Core component responsible for orchestrating the word cloud generation process.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Image Drawing & Rendering
+
+Component responsible for drawing words onto the final image using calculated positions.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Text_Processing.md
+++ b/.codeboarding/Text_Processing.md
@@ -1,0 +1,51 @@
+```mermaid
+
+graph LR
+
+    Text_Processing["Text Processing"]
+
+    Text_Processing -- "uses" --> Stopwords_Management
+
+    WordCloud_Core -- "uses" --> Text_Processing
+
+    click Text_Processing href "https://github.com/amueller/word_cloud/blob/main/.codeboarding//Text_Processing.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of the Text Processing component, its functionalities, and its interactions within the word cloud generation system for word cloud generation. This component is fundamental for preparing raw text by handling tokenization, stopword removal, plural normalization, and collocation identification, which are crucial for accurate frequency counts and meaningful visualization. It interacts with 'Stopwords Management' for filtering and is utilized by 'WordCloud Core' to process input text into word frequencies for visualization.
+
+
+
+### Text Processing
+
+This component is dedicated to transforming raw input text into a structured format suitable for word cloud generation. It handles essential tasks such as tokenization (breaking text into individual words), removing common stopwords, normalizing plurals, and identifying significant collocations (bigrams) based on statistical measures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L38-L71" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization.unigrams_and_bigrams` (38:71)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L74-L137" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization.process_tokens` (74:137)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,153 @@
+```mermaid
+
+graph LR
+
+    WordCloud_Core["WordCloud Core"]
+
+    Text_Processing["Text Processing"]
+
+    Layout_Engine["Layout Engine"]
+
+    Coloring_Strategies["Coloring Strategies"]
+
+    Command_Line_Interface["Command Line Interface"]
+
+    WordCloud_Core -- "uses" --> Text_Processing
+
+    WordCloud_Core -- "uses" --> Layout_Engine
+
+    WordCloud_Core -- "uses" --> Coloring_Strategies
+
+    Text_Processing -- "is used by" --> WordCloud_Core
+
+    Layout_Engine -- "is used by" --> WordCloud_Core
+
+    Coloring_Strategies -- "is used by" --> WordCloud_Core
+
+    Coloring_Strategies -- "is used by" --> Command_Line_Interface
+
+    Command_Line_Interface -- "uses" --> WordCloud_Core
+
+    Command_Line_Interface -- "uses" --> Coloring_Strategies
+
+    click Text_Processing href "https://github.com/amueller/word_cloud/blob/main/.codeboarding//Text_Processing.md" "Details"
+
+    click Layout_Engine href "https://github.com/amueller/word_cloud/blob/main/.codeboarding//Layout_Engine.md" "Details"
+
+    click Coloring_Strategies href "https://github.com/amueller/word_cloud/blob/main/.codeboarding//Coloring_Strategies.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Based on the Control Flow Graph (CFG) analysis and the detailed Source Analysis, the `word_cloud` project's architecture can be distilled into five fundamental components. These components represent distinct functional areas, ensuring modularity and clear responsibilities within the system.
+
+
+
+### WordCloud Core
+
+This is the central orchestrator of the entire word cloud generation process. It manages the overall workflow, from accepting text input and configuration parameters to coordinating text processing, word placement, and final image rendering. It acts as the primary interface for generating a word cloud.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L153-L1041" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud:WordCloud` (153:1041)</a>
+
+
+
+
+
+### Text Processing
+
+This component is dedicated to transforming raw input text into a structured format suitable for word cloud generation. It handles essential tasks such as tokenization (breaking text into individual words), removing common stopwords, normalizing plurals, and identifying significant collocations (bigrams) based on statistical measures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/tokenization.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.tokenization` (0:0)</a>
+
+
+
+
+
+### Layout Engine
+
+Crucial for the visual arrangement of words, this component efficiently places words on the canvas. It utilizes an IntegralOccupancyMap data structure, which leverages a C extension (query_integral_image) for high-performance operations, ensuring words are placed without overlapping and optimizing the density of the word cloud.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L37-L66" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud:IntegralOccupancyMap` (37:66)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.query_integral_image` (0:0)</a>
+
+
+
+
+
+### Coloring Strategies
+
+This component provides diverse methods for determining the color of each word in the word cloud. It includes functionality to derive colors directly from an input image, apply a predefined Matplotlib colormap, or assign a single, uniform color across all words.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/color_from_image.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.color_from_image` (0:0)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L90-L113" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud:colormap_color_func` (90:113)</a>
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud.py#L116-L150" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud:get_single_color_func` (116:150)</a>
+
+
+
+
+
+### Command Line Interface
+
+This module provides a user-friendly command-line interface, allowing users to generate word clouds directly from the terminal without needing to write Python code. It parses command-line arguments and orchestrates the WordCloud Core object to produce the desired output.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/amueller/word_cloud/blob/master/wordcloud/wordcloud_cli.py#L0-L0" target="_blank" rel="noopener noreferrer">`wordcloud.wordcloud_cli` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
Hi! This PR adds high-level diagrams of the word_cloud codebase to help new contributors quickly get oriented.
You can see how the proposed changes render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/word_cloud/on_boarding.md

The idea is to make onboarding easier—especially for open-source contributors who typically want to work on a specific module. Visualizing the codebase helps people understand how things fit together without needing to read everything up front. With more than 2.3K forks, you have a lot of contributors who are not just users, but rather want to fiddle around with the codebase itself. With the visualization they can see the big picture and focus only on the component they are interested in.

We’ve also released a free GitHub Action that keeps the diagrams automatically updated as the code changes, so there's no ongoing maintenance burden.

Any feedback is more than welcome!

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.