### PR TITLE
Update cibuildwheel version to v3.3.0 to get python-3.14 wheels

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -22,7 +22,7 @@ jobs:
           git fetch --prune --unshallow
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.3.0
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
I'm not sure it's the way, but I don't see another way. Having Python-3.14 wheels, even just for the non free-threading version,  would be great 